### PR TITLE
Optimistically update the local cache when the user joins a group

### DIFF
--- a/client/src/graphql/join-group.mutation.js
+++ b/client/src/graphql/join-group.mutation.js
@@ -4,6 +4,7 @@ export default gql`
   mutation addUserToGroup($groupUpdate: AddUserToGroupInput!) {
     addUserToGroup(groupUpdate: $groupUpdate) {
       id
+      name
     }
   }
 `;

--- a/client/src/screens/new-group.screen.js
+++ b/client/src/screens/new-group.screen.js
@@ -181,7 +181,7 @@ const createGroupMutation = graphql(CREATE_GROUP_MUTATION, {
           // Read the data from our cache for this query.
           const data = store.readQuery({
             query: CURRENT_USER_QUERY,
-            variables: { id: ownProps.auth.id },
+            variables: { id: ownProps.auth.token },
           });
 
           // Add our message from the mutation to the end.
@@ -190,7 +190,7 @@ const createGroupMutation = graphql(CREATE_GROUP_MUTATION, {
           // Write our data back to the cache.
           store.writeQuery({
             query: CURRENT_USER_QUERY,
-            variables: { id: ownProps.auth.id },
+            variables: { id: ownProps.auth.token },
             data,
           });
         },

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -4,93 +4,109 @@ export const loadTestData = () =>
   Creators.organisation({
     name: 'NSW SES',
   }).then(organisation =>
-    Creators.user({
-      id: 69,
-      username: 'chris',
-      password: 'testing',
-      email: 'test@miceli.net.au',
-      organisation,
-    }).then(user =>
-      Promise.all([
-        Creators.device({
-          uuid: '1234abc',
-          user,
-        }),
-        Creators.capability({
-          name: 'Road Crash Rescue',
-          organisation,
-          user,
-        }),
-        Creators.capability({
-          name: 'Vertical Rescue',
-          organisation,
-          user,
-        }),
-        Creators.capability({
-          name: 'Flood Rescue',
-          organisation,
-          user,
-        }),
-        Creators.capability({
-          name: 'Chainsaw',
-          organisation,
-          user,
-        }),
-        Creators.group({
-          name: 'Kiama',
-          user,
-          organisation,
-        }),
-        Creators.group({
-          name: 'Parramatta',
-          user,
-          organisation,
-        }),
-        Creators.group({
-          name: 'Wollongong',
-          organisation,
-          user,
-        }).then(group => Promise.all([
-          Creators.schedule({
-            group,
-            name: 'Wollongong S&W',
-            details: 'Weekly storm availability',
+    Promise.all([
+      Creators.user({
+        id: 68,
+        username: 'tim',
+        password: '123',
+        email: 'test@test.com',
+        organisation,
+      }),
+      Creators.user({
+        id: 69,
+        username: 'chris',
+        password: 'testing',
+        email: 'test@miceli.net.au',
+        organisation,
+      }).then(user =>
+        Promise.all([
+          Creators.user({
+            id: 70,
+            username: 'tim',
+            password: '123',
+            email: 'tim@tim.com',
+            organisation,
           }),
-          Creators.schedule({
-            group,
-            name: 'Wollongong VR',
-            details: 'Weekly VR availability',
+          Creators.device({
+            uuid: '1234abc',
+            user,
           }),
-          Creators.schedule({
-            group,
-            name: 'Emergency Services Expo',
-            details: '5 people needed for demonstrations on Sunday',
-          }),
-          Creators.tag({
-            name: 'Wollongong City',
+          Creators.capability({
+            name: 'Road Crash Rescue',
             organisation,
             user,
-            group,
           }),
-          Creators.tag({
-            name: 'Corrimal',
+          Creators.capability({
+            name: 'Vertical Rescue',
             organisation,
             user,
-            group,
           }),
-          Creators.event({
-            name: 'VR Wollongong Escarpment',
-            details: 'VR operators required to assist with rescue',
-            group,
+          Creators.capability({
+            name: 'Flood Rescue',
+            organisation,
+            user,
           }),
-          Creators.event({
-            name: 'Assist ASNSW',
-            details: 'Needed to carry patient over rough terrain',
-            group,
+          Creators.capability({
+            name: 'Chainsaw',
+            organisation,
+            user,
           }),
-        ])),
-      ]),
-    ),
+          Creators.group({
+            name: 'Kiama',
+            user,
+            organisation,
+          }),
+          Creators.group({
+            name: 'Parramatta',
+            user,
+            organisation,
+          }),
+          Creators.group({
+            name: 'Wollongong',
+            organisation,
+            user,
+          }).then(group => Promise.all([
+            Creators.schedule({
+              group,
+              name: 'Wollongong S&W',
+              details: 'Weekly storm availability',
+            }),
+            Creators.schedule({
+              group,
+              name: 'Wollongong VR',
+              details: 'Weekly VR availability',
+            }),
+            Creators.schedule({
+              group,
+              name: 'Emergency Services Expo',
+              details: '5 people needed for demonstrations on Sunday',
+            }),
+            Creators.tag({
+              name: 'Wollongong City',
+              organisation,
+              user,
+              group,
+            }),
+            Creators.tag({
+              name: 'Corrimal',
+              organisation,
+              user,
+              group,
+            }),
+            Creators.event({
+              name: 'VR Wollongong Escarpment',
+              details: 'VR operators required to assist with rescue',
+              group,
+            }),
+            Creators.event({
+              name: 'Assist ASNSW',
+              details: 'Needed to carry patient over rough terrain',
+              group,
+            }),
+          ])),
+        ]),
+      ),
+    ]),
   );
 
 export default loadTestData;


### PR DESCRIPTION
update group search and join screens to use Graphql caching.

Im stuck on the following with an undefined variable.

```
const joinGroupQuery = graphql(JOIN_GROUP_QUERY, {
  props: ({ ownProps, mutate }) => ({
    groupUpdate: ({ groupId }) =>
      mutate({
        variables: { groupUpdate: { groupId } },
        update: (store, { data: { groupUpdate } }) => {
          const data = store.readQuery({
            query: ALL_GROUPS_QUERY,
            variables: { id: ownProps.auth.token },
          });
          data.user.groups.push(groupUpdate);
          store.writeQuery({
            query: ALL_GROUPS_QUERY,
            variables: { id: ownProps.auth.token },
            data,
          });
        },
      }),
  }),
});
```

data.user.groups.push(groupUpdate); - groupUpdate is undefined.

I can see data is coming back as i have a then() on the call which contains the new group created buy for some reason I cant get it inside the update call.