### PR TITLE
Fixes bad filter used to update graphQL cache on new group page

### DIFF
--- a/client/src/screens/new-group.screen.js
+++ b/client/src/screens/new-group.screen.js
@@ -173,7 +173,7 @@ FinalizeGroup.propTypes = {
 };
 
 const createGroupMutation = graphql(CREATE_GROUP_MUTATION, {
-  props: ({ ownProps, mutate }) => ({
+  props: ({ mutate }) => ({
     createGroup: ({ name }) =>
       mutate({
         variables: { group: { name } },
@@ -181,16 +181,14 @@ const createGroupMutation = graphql(CREATE_GROUP_MUTATION, {
           // Read the data from our cache for this query.
           const data = store.readQuery({
             query: CURRENT_USER_QUERY,
-            variables: { id: ownProps.auth.id },
           });
 
-          // Add our message from the mutation to the end.
+          // Add our group from the mutation to the end.
           data.user.groups.push(createGroup);
 
           // Write our data back to the cache.
           store.writeQuery({
             query: CURRENT_USER_QUERY,
-            variables: { id: ownProps.auth.id },
             data,
           });
         },


### PR DESCRIPTION
was using a variable that didnt exist