### PR TITLE
Mutation query cache for Groups

### DIFF
--- a/client/src/graphql/all-groups.query.js
+++ b/client/src/graphql/all-groups.query.js
@@ -5,7 +5,10 @@ export default gql`
   query {
     user {
       id
+      username
       organisation {
+        id
+        name
          groups {
             name
             id

--- a/client/src/graphql/join-group.mutation.js
+++ b/client/src/graphql/join-group.mutation.js
@@ -4,6 +4,15 @@ export default gql`
   mutation addUserToGroup($groupUpdate: AddUserToGroupInput!) {
     addUserToGroup(groupUpdate: $groupUpdate) {
       id
+      name
+      tags {
+         name
+         id
+       }
+       users {
+         username
+         id
+       }
     }
   }
 `;


### PR DESCRIPTION
Added update function to groups mutation to enable predictive UI for joining a group and viewing joined groups.

![group cache](https://user-images.githubusercontent.com/5799222/33209412-c2d10fe2-d169-11e7-9648-5a58ea7780ce.gif)
