### PR TITLE
fix object type in prototype on group page to be object not string

### DIFF
--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -129,7 +129,22 @@ Group.propTypes = {
   navigation: PropTypes.shape({
     state: PropTypes.shape({
       params: PropTypes.shape({
-        group: PropTypes.object,
+        group: PropTypes.shape({
+          id: PropTypes.number,
+          name: PropTypes.string,
+          tags: PropTypes.arrayOf(
+            PropTypes.shape({
+              id: PropTypes.number.isRequired,
+              name: PropTypes.string.isRequired,
+            }),
+          ),
+          users: PropTypes.arrayOf(
+            PropTypes.shape({
+              id: PropTypes.number.isRequired,
+              username: PropTypes.string.isRequired,
+            }),
+          ),
+        }),
       }),
     }),
   }),

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -129,7 +129,7 @@ Group.propTypes = {
   navigation: PropTypes.shape({
     state: PropTypes.shape({
       params: PropTypes.shape({
-        group: PropTypes.string.isRequired,
+        group: PropTypes.object,
       }),
     }),
   }),


### PR DESCRIPTION
Dunno how we didnt notice that.