### PR TITLE
Default to using local GraphQL server if __DEV__

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -6,6 +6,9 @@ module.exports = {
     "jsx-a11y",
     "import"
   ],
+  "globals": {
+    "__DEV__": false, // enforce immutability
+  },
   "rules": {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/require-default-props": [0],

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,2 +1,5 @@
-export const GRAPHQL_ENDPOINT = 'https://ses-availability-api.herokuapp.com/graphql';
+export const GRAPHQL_ENDPOINT_PROD = 'https://ses-availability-api.herokuapp.com/graphql';
+export const GRAPHQL_ENDPOINT_LOCAL = 'http://localhost:8080/graphql';
+
+export const GRAPHQL_ENDPOINT = __DEV__ ? GRAPHQL_ENDPOINT_LOCAL : GRAPHQL_ENDPOINT_PROD;
 export default GRAPHQL_ENDPOINT;


### PR DESCRIPTION
* When `__DEV__` is true (development builds of the app/react native bundler is running) we default to using `http://localhost:8080/graphql`.
* This might not work for everyone but that is OK - they can change it.
* If someone accidentally commits their local IP or whatever it won't affect production builds.
* Closes #63