### PR TITLE
Updated resolvers & logic to support events -> responses.

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,5 +1,5 @@
 export const GRAPHQL_ENDPOINT_PROD = 'https://ses-availability-api.herokuapp.com/graphql';
-export const GRAPHQL_ENDPOINT_LOCAL = 'http://localhost:8080/graphql';
+export const GRAPHQL_ENDPOINT_LOCAL = 'http://172.16.0.21:8080/graphql';
 
 export const GRAPHQL_ENDPOINT = __DEV__ ? GRAPHQL_ENDPOINT_LOCAL : GRAPHQL_ENDPOINT_PROD;
 export default GRAPHQL_ENDPOINT;

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,5 +1,5 @@
 export const GRAPHQL_ENDPOINT_PROD = 'https://ses-availability-api.herokuapp.com/graphql';
-export const GRAPHQL_ENDPOINT_LOCAL = 'http://local:8080/graphql';
+export const GRAPHQL_ENDPOINT_LOCAL = 'http://localhost:8080/graphql';
 
 export const GRAPHQL_ENDPOINT = __DEV__ ? GRAPHQL_ENDPOINT_LOCAL : GRAPHQL_ENDPOINT_PROD;
 export default GRAPHQL_ENDPOINT;

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,5 +1,5 @@
 export const GRAPHQL_ENDPOINT_PROD = 'https://ses-availability-api.herokuapp.com/graphql';
-export const GRAPHQL_ENDPOINT_LOCAL = 'http://172.16.0.21:8080/graphql';
+export const GRAPHQL_ENDPOINT_LOCAL = 'http://local:8080/graphql';
 
 export const GRAPHQL_ENDPOINT = __DEV__ ? GRAPHQL_ENDPOINT_LOCAL : GRAPHQL_ENDPOINT_PROD;
 export default GRAPHQL_ENDPOINT;

--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -2,7 +2,7 @@ import bcrypt from 'bcrypt';
 
 import {
   Organisation, Group, User, Capability, Tag, Device, Event,
-  Schedule, TimeSegment,
+  Schedule, TimeSegment, EventResponse,
 } from './models';
 
 const creators = {
@@ -121,6 +121,23 @@ const creators = {
       endTime,
       userId: user.id,
       scheduleId: schedule.id,
+    });
+  },
+
+  eventResponse: ({ status, detail, destination, eta, event, user }) => {
+    if (!user || !user.id) {
+      return Promise.reject(Error('Must pass user'));
+    }
+    if (!event || !event.id) {
+      return Promise.reject(Error('Must pass event'));
+    }
+    return EventResponse.create({
+      status,
+      detail,
+      destination,
+      eta,
+      userId: user.id,
+      eventId: event.id,
     });
   },
 };

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -1,7 +1,8 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import JWT_SECRET from './config';
-import { Group,
+import {
+  Group,
   User,
   Device,
   Organisation,
@@ -220,8 +221,8 @@ export const scheduleHandler = {
 };
 
 export const eventHandler = {
-  group(eventt) {
-    return eventt.getGroup();
+  group(event) {
+    return event.getGroup();
   },
   responses(event) {
     return EventResponse.findAll({

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -1,9 +1,15 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-
-
 import JWT_SECRET from './config';
-import { Group, User, Device, Organisation, Schedule, TimeSegment } from './models';
+import { Group,
+  User,
+  Device,
+  Organisation,
+  Schedule,
+  TimeSegment,
+  Event,
+  EventResponse,
+} from './models';
 import Creators from './creators';
 
 // reusable function to check for a user with context
@@ -58,7 +64,10 @@ export const userHandler = {
     return user.getGroups();
   },
   events(user) {
-    return user.getEvents();
+    return user.getGroups()
+      .then(groups => Event.findAll({
+        where: { groupId: groups.map(g => g.id) },
+      }));
   },
   schedules(user) {
     return user.getGroups()
@@ -207,6 +216,23 @@ export const scheduleHandler = {
           group,
         });
       });
+  },
+};
+
+export const eventHandler = {
+  group(eventt) {
+    return eventt.getGroup();
+  },
+  responses(event) {
+    return EventResponse.findAll({
+      where: { EventId: event.id },
+    });
+  },
+};
+
+export const eventResponseHandler = {
+  user(response) {
+    return response.getUser();
   },
 };
 

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -60,7 +60,7 @@ const TimeSegmentModel = db.define('timesegment', {
 });
 
 const EventResponseModel = db.define('eventresponse', {
-  status: { type: Sequelize.INTEGER },
+  status: { type: Sequelize.STRING },
   detail: { type: Sequelize.STRING },
   destination: { type: Sequelize.STRING },
   eta: { type: Sequelize.INTEGER },

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -59,6 +59,13 @@ const TimeSegmentModel = db.define('timesegment', {
   lastUpdate: { type: Sequelize.INTEGER },
 });
 
+const EventResponseModel = db.define('eventresponse', {
+  status: { type: Sequelize.INTEGER },
+  detail: { type: Sequelize.STRING },
+  destination: { type: Sequelize.STRING },
+  eta: { type: Sequelize.INTEGER },
+});
+
 // users <-> groups (many-to-many)
 UserModel.belongsToMany(GroupModel, { through: 'group_user' });
 GroupModel.belongsToMany(UserModel, { through: 'group_user' });
@@ -105,6 +112,12 @@ ScheduleModel.hasMany(TimeSegmentModel);
 TimeSegmentModel.belongsTo(UserModel);
 UserModel.hasMany(TimeSegmentModel);
 
+// event responses belong to a combination of user/event
+EventResponseModel.belongsTo(EventModel);
+EventModel.hasMany(EventResponseModel);
+EventResponseModel.belongsTo(UserModel);
+UserModel.hasMany(EventResponseModel);
+
 // tags belong to one organisation for now
 TagModel.belongsTo(OrganisationModel);
 OrganisationModel.hasMany(TagModel);
@@ -121,6 +134,7 @@ const Capability = db.models.capability;
 const Tag = db.models.tag;
 const Device = db.models.device;
 const Event = db.models.event;
+const EventResponse = db.models.eventresponse;
 const Schedule = db.models.schedule;
 const TimeSegment = db.models.timesegment;
 
@@ -131,4 +145,15 @@ db.sync({ force: true }).then(() => loadTestData()).then(() => {
   console.log(e);
 });
 
-export { Organisation, Capability, Tag, Group, User, Device, Event, Schedule, TimeSegment };
+export {
+  Organisation,
+  Capability,
+  Tag,
+  Group,
+  User,
+  Device,
+  Event,
+  Schedule,
+  TimeSegment,
+  EventResponse,
+};

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -4,6 +4,8 @@ import {
   groupHandler,
   userHandler,
   organisationHandler,
+  eventHandler,
+  eventResponseHandler,
 } from './logic';
 
 export const Resolvers = {
@@ -53,6 +55,19 @@ export const Resolvers = {
     },
     group(schedule, args, ctx) {
       return scheduleHandler.group(schedule, args, ctx);
+    },
+  },
+  Event: {
+    group(event, args, ctx) {
+      return eventHandler.group(event, args, ctx);
+    },
+    responses(eventt, args, ctx) {
+      return eventHandler.responses(eventt, args, ctx);
+    },
+  },
+  EventResponse: {
+    user(response, args, ctx) {
+      return eventResponseHandler.user(response, args, ctx);
     },
   },
   Organisation: {

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -101,10 +101,10 @@ export const Schema = [`
   }
 
   type Event {
-    group: Group!
     id: Int!
     name: String!
     details: String!
+    group: Group!
     responses: [EventResponse]!
   }
 

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -101,6 +101,7 @@ export const Schema = [`
   }
 
   type Event {
+    group: Group!
     id: Int!
     name: String!
     details: String!
@@ -112,6 +113,8 @@ export const Schema = [`
     user: User!
     status: String!
     detail: String!
+    destination: String!
+    eta: Int!
   }
 
   type Schedule {

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -110,7 +110,7 @@ export const loadTestData = () =>
                 status: 'On Route',
                 detail: 'Attending',
                 destination: 'Scene',
-                eta: 600,
+                eta: 1517443200,
                 event,
                 user,
               }),

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -105,7 +105,16 @@ export const loadTestData = () =>
               name: 'VR Wollongong Escarpment',
               details: 'VR operators required to assist with rescue',
               group,
-            }),
+            }).then(event =>
+              Creators.eventResponse({
+                status: 'On Route',
+                detail: 'Attending',
+                destination: 'Scene',
+                eta: 600,
+                event,
+                user,
+              }),
+            ),
             Creators.event({
               name: 'Assist ASNSW',
               details: 'Needed to carry patient over rough terrain',

--- a/server/tests/current-user.test.js
+++ b/server/tests/current-user.test.js
@@ -134,13 +134,15 @@ describe('GraphQL query - Current user', () => {
           id
           events {
             id
+            name
             responses {
               status
-              event {
-                id
-              }
+              detail
+              destination
+              eta
               user {
                 id
+                username
               }
             }
           }
@@ -149,6 +151,18 @@ describe('GraphQL query - Current user', () => {
     `);
 
     itReturnsSuccess(response);
+    it('Returns entity', () => response.then((res) => {
+      expect(res.data.user.events[0]).toHaveProperty('id');
+      expect(res.data.user.events[0]).toHaveProperty('name');
+    }));
+    it('Returns responses', () => response.then((res) => {
+      expect(res.data.user.events[0].responses[0]).toHaveProperty('status');
+      expect(res.data.user.events[0].responses[0]).toHaveProperty('detail');
+      expect(res.data.user.events[0].responses[0]).toHaveProperty('destination');
+      expect(res.data.user.events[0].responses[0]).toHaveProperty('eta');
+      expect(res.data.user.events[0].responses[0].user).toHaveProperty('id');
+      expect(res.data.user.events[0].responses[0].user).toHaveProperty('username');
+    }));
   });
 
   describe('Get devices', () => {


### PR DESCRIPTION
Created logic paths to support returning events and responses under user.

Creators to create event response
logic to handle elements returned for event and responses
model to have event response model, and relationships
schema to handle data return
test-data to populate an event response for test user
just test to test the above


Question:

Do we want user -> events -> responses to show all responses or just current users?

I would suggest it only show current users answers, as it lives under user? But I can see the argument to show all users responses for cache reasons. Possibly put under user -> org -> events everyones responses? This question needs to be answered for schedules as well as it has the same sorta scope. I have coded this to show all users responses. Code assumes user is in the group that the event is attached to, we need to do some re-jig to change that logic, possibly expose this under user -> org -> events if we want non member users to see it.