### PR TITLE
API for getting events/schedules by ID

### DIFF
--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -10,6 +10,7 @@ import {
   Event,
 } from './models';
 import Creators from './creators';
+import { schedulePerms, eventPerms } from './perms';
 
 // reusable function to check for a user with context
 const getAuthenticatedUser = ctx => ctx.user.then((user) => {
@@ -195,6 +196,18 @@ export const userHandler = {
 };
 
 export const scheduleHandler = {
+  query(_, args, ctx) {
+    // fetch a schedule by ID but ensure the user is allowed to read it
+    if (!args.id) {
+      return Promise.reject(Error('Must pass ID'));
+    }
+
+    // this Promise returns the schedule if the user is allowed to read it
+    return schedulePerms.userWantsToRead({
+      user: getAuthenticatedUser(ctx),
+      schedule: Schedule.findById(args.id),
+    });
+  },
   timeSegments(schedule) {
     return schedule.getTimesegments();
   },
@@ -225,6 +238,18 @@ export const timeSegmentHandler = {
 };
 
 export const eventHandler = {
+  query(_, args, ctx) {
+    // fetch an event by ID but ensure the user is allowed to read it
+    if (!args.id) {
+      return Promise.reject(Error('Must pass ID'));
+    }
+
+    // this Promise returns the event if the user is allowed to read it
+    return eventPerms.userWantsToRead({
+      user: getAuthenticatedUser(ctx),
+      event: Event.findById(args.id),
+    });
+  },
   group(event) {
     return event.getGroup();
   },

--- a/server/src/perms.js
+++ b/server/src/perms.js
@@ -1,0 +1,63 @@
+export const schedulePerms = {
+  userWantsToRead({ user: userPromise, schedule: schedulePromise }) {
+    // TODO: decide whether to allow users who are not a member of the group the schedule is for to
+    // see it
+    return Promise.all([
+      userPromise,
+      schedulePromise,
+    ]).then(([user, schedule]) => {
+      if (!user) {
+        return Promise.reject(Error('Invalid user'));
+      }
+      if (!schedule) {
+        return Promise.reject(Error('Invalid schedule'));
+      }
+
+      return Promise.resolve(schedule.getGroup()).then((group) => {
+        if (!group) {
+          return Promise.reject(Error('Invalid group'));
+        }
+
+        if (user.organisationId !== group.organisationId) {
+          return Promise.reject(
+            Error('Permission denied - this schedule isnt part of your organisation'),
+          );
+        }
+
+        return schedule;
+      });
+    });
+  },
+};
+
+export const eventPerms = {
+  userWantsToRead({ user: userPromise, event: eventPromise }) {
+    // TODO: decide whether to allow users who are not a member of the group the event is for to
+    // see it
+    return Promise.all([
+      userPromise,
+      eventPromise,
+    ]).then(([user, event]) => {
+      if (!user) {
+        return Promise.reject(Error('Invalid user'));
+      }
+      if (!event) {
+        return Promise.reject(Error('Invalid event'));
+      }
+
+      return Promise.resolve(event.getGroup()).then((group) => {
+        if (!group) {
+          return Promise.reject(Error('Invalid group'));
+        }
+
+        if (user.organisationId !== group.organisationId) {
+          return Promise.reject(
+            Error('Permission denied - this event isnt part of your organisation'),
+          );
+        }
+
+        return event;
+      });
+    });
+  },
+};

--- a/server/src/perms.test.js
+++ b/server/src/perms.test.js
@@ -1,0 +1,149 @@
+import { schedulePerms, eventPerms } from './perms';
+
+describe('Schedule permissions', () => {
+  describe('allowed', () => {
+    const user = {
+      organisationId: 69,
+    };
+    const schedule = {
+      getGroup: () => ({
+        organisationId: 69,
+      }),
+    };
+
+    it('with no promises', () =>
+      expect(schedulePerms.userWantsToRead({ user, schedule }))
+        .resolves.toBe(schedule),
+    );
+
+    it('with promises', () =>
+      expect(schedulePerms.userWantsToRead({
+        user: Promise.resolve(user),
+        schedule: Promise.resolve(schedule),
+      }))
+        .resolves.toBe(schedule),
+    );
+  });
+
+  describe('denied', () => {
+    it('wrong org', () => {
+      const user = {
+        organisationId: 69,
+      };
+      const schedule = {
+        getGroup: () => ({
+          organisationId: 1,
+        }),
+      };
+
+      return expect(schedulePerms.userWantsToRead({ user, schedule }))
+        .rejects.toThrow();
+    });
+
+    it('invalid group', () => {
+      const user = {
+        organisationId: 69,
+      };
+      const schedule = {
+        getGroup: () => null,
+      };
+
+      return expect(schedulePerms.userWantsToRead({ user, schedule }))
+        .rejects.toThrow();
+    });
+
+    it('invalid user', () => {
+      const schedule = {
+        getGroup: () => ({
+          organisationId: 1,
+        }),
+      };
+
+      return expect(schedulePerms.userWantsToRead({ user: null, schedule }))
+        .rejects.toThrow();
+    });
+
+    it('invalid schedule', () => {
+      const user = {
+        organisationId: 69,
+      };
+
+      return expect(schedulePerms.userWantsToRead({ user, schedule: null }))
+        .rejects.toThrow();
+    });
+  });
+});
+
+describe('Event permissions', () => {
+  describe('allowed', () => {
+    const user = {
+      organisationId: 69,
+    };
+    const event = {
+      getGroup: () => ({
+        organisationId: 69,
+      }),
+    };
+
+    it('with no promises', () =>
+      expect(eventPerms.userWantsToRead({ user, event }))
+        .resolves.toBe(event),
+    );
+
+    it('with promises', () =>
+      expect(eventPerms.userWantsToRead({
+        user: Promise.resolve(user),
+        event: Promise.resolve(event),
+      }))
+        .resolves.toBe(event),
+    );
+  });
+
+  describe('denied', () => {
+    it('wrong org', () => {
+      const user = {
+        organisationId: 69,
+      };
+      const event = {
+        getGroup: () => ({
+          organisationId: 1,
+        }),
+      };
+
+      return expect(eventPerms.userWantsToRead({ user, event }))
+        .rejects.toThrow();
+    });
+
+    it('invalid group', () => {
+      const user = {
+        organisationId: 69,
+      };
+      const event = {
+        getGroup: () => null,
+      };
+
+      return expect(eventPerms.userWantsToRead({ user, event }))
+        .rejects.toThrow();
+    });
+
+    it('invalid user', () => {
+      const event = {
+        getGroup: () => ({
+          organisationId: 1,
+        }),
+      };
+
+      return expect(eventPerms.userWantsToRead({ user: null, event }))
+        .rejects.toThrow();
+    });
+
+    it('invalid event', () => {
+      const user = {
+        organisationId: 69,
+      };
+
+      return expect(eventPerms.userWantsToRead({ user, event: null }))
+        .rejects.toThrow();
+    });
+  });
+});

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -97,6 +97,12 @@ export const Resolvers = {
     device(_, args, ctx) {
       return deviceHandler.query(_, args, ctx);
     },
+    event(_, args, ctx) {
+      return eventHandler.query(_, args, ctx);
+    },
+    schedule(_, args, ctx) {
+      return scheduleHandler.query(_, args, ctx);
+    },
   },
   Mutation: {
     createGroup(_, args, ctx) {

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -140,6 +140,12 @@ export const Schema = [`
 
     # Get the entity representing the current device
     device: Device
+
+    # return an event by ID
+    event(id: Int!): Event
+
+    # return a schedule by ID
+    schedule(id: Int!): Schedule
   }
 
   type Mutation {

--- a/server/tests/event.test.js
+++ b/server/tests/event.test.js
@@ -1,0 +1,33 @@
+import { query, itReturnsSuccess } from './common';
+
+// this query is made as the default user
+describe('GraphQL query - Event', () => {
+  describe('Event by ID', () => {
+    const response = query(`
+      {
+        event(id: 1) {
+          id
+          name
+          details
+          group {
+            id
+          }
+          responses {
+            user {
+              username
+            }
+            detail
+          }
+        }
+      }
+    `);
+
+    itReturnsSuccess(response);
+    it('Returns id', () =>
+      expect(response).resolves.toHaveProperty('data.event.id'),
+    );
+    it('Returns name', () =>
+      expect(response).resolves.toHaveProperty('data.event.name'),
+    );
+  });
+});


### PR DESCRIPTION
* Respects organisation permissions (you must be a member of the event's group's organisation)
  * New `perms.js` to store this logic
  * Complete unit test coverage
* New unit tests require beta version of `jest` due to bug checking for rejected Promises.