### PR TITLE
Handle users with invalid auth tokens more gracefully

### DIFF
--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -4,7 +4,6 @@ import JWT_SECRET from './config';
 import {
   Group,
   User,
-  Device,
   Organisation,
   Schedule,
   Event,
@@ -14,18 +13,18 @@ import { schedulePerms, eventPerms } from './perms';
 
 // reusable function to check for a user with context
 const getAuthenticatedUser = ctx => ctx.user.then((user) => {
+  // null means we couldn't find the user record
   if (!user) {
-    // XXX: remove this
-    return User.findById(69);
-    // return Promise.reject('Unauthorized');
+    // eslint-disable-next-line prefer-promise-reject-errors
+    return Promise.reject('Unauthorized: Invalid user ID');
   }
   return user;
 });
 
 const getAuthenticatedDevice = ctx => ctx.device.then((device) => {
   if (!device) {
-    return Device.findOne({ where: { userId: 69, uuid: '1234abc' } });
-    // return Promise.reject('Unauthorized');
+    // eslint-disable-next-line prefer-promise-reject-errors
+    return Promise.reject('Unauthorized: Device not found');
   }
   return device;
 });


### PR DESCRIPTION
* If a user has a valid JWT but it points to an invalid user or device we return an unauthorized message which gets caught by the client and automatically logs them out with a cute error message.
* This also moves the logic we have that fakes a login as our test user for graphiql and other requests with no auth header.