### PR TITLE
Properly wipe the apollo store on logout

### DIFF
--- a/client/src/state/auth.actions.js
+++ b/client/src/state/auth.actions.js
@@ -7,6 +7,8 @@ export const setCurrentUser = user => ({
 });
 
 export const logout = () => {
-  client.resetStore();
+  // we run this on the next frame so that the reducer has time to complete before
+  // we fully wipe the store. Otherwise some stuff gets left over.
+  setTimeout(client.resetStore);
   return { type: LOGOUT };
 };


### PR DESCRIPTION
* This was a long standing bug that would manifest as you appearing to see another user's details when logging in and out. It would basically show you cached data for the previously logged in user.
* This fixes #15 finally.