### PR TITLE
TimeSegment Resolvers & Mutations + Schedule start/stop

### DIFF
--- a/server/src/constants.js
+++ b/server/src/constants.js
@@ -1,0 +1,3 @@
+const distantFuture = 2147483647;
+
+export default distantFuture;

--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -13,7 +13,7 @@ const creators = {
     if (!group || !group.id) {
       return Promise.reject(Error('Must pass group'));
     }
-    if (!startTime || !endTime) {
+    if (typeof startTime === 'undefined' || typeof endTime === 'undefined') {
       return Promise.reject(Error('Must pass start and end times'));
     }
     return Schedule.create({
@@ -121,7 +121,7 @@ const creators = {
     if (!schedule || !schedule.id) {
       return Promise.reject(Error('Must pass schedule'));
     }
-    if (!startTime || !endTime) {
+    if (typeof startTime === 'undefined' || typeof endTime === 'undefined') {
       return Promise.reject(Error('Must pass start and end times'));
     }
     return TimeSegment.create({

--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -13,6 +13,9 @@ const creators = {
     if (!group || !group.id) {
       return Promise.reject(Error('Must pass group'));
     }
+    if (!startTime || !endTime) {
+      return Promise.reject(Error('Must pass start and end times'));
+    }
     return Schedule.create({
       name,
       details,
@@ -117,6 +120,9 @@ const creators = {
     }
     if (!schedule || !schedule.id) {
       return Promise.reject(Error('Must pass schedule'));
+    }
+    if (!startTime || !endTime) {
+      return Promise.reject(Error('Must pass start and end times'));
     }
     return TimeSegment.create({
       status,

--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -9,13 +9,15 @@ const creators = {
   organisation: ({ name }) =>
     Organisation.create({ name }),
 
-  schedule: ({ name, details, group }) => {
+  schedule: ({ name, details, startTime, endTime, group }) => {
     if (!group || !group.id) {
       return Promise.reject(Error('Must pass group'));
     }
     return Schedule.create({
       name,
       details,
+      startTime,
+      endTime,
       groupId: group.id,
     });
   },

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -268,7 +268,7 @@ export const timeSegmentHandler = {
         }),
       );
   },
-  editTimeSegment(_, args, ctx) {
+  updateTimeSegment(_, args, ctx) {
     const { segmentId, status, startTime, endTime } = args.timeSegment;
     return getAuthenticatedUser(ctx)
       .then(() =>

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -7,6 +7,7 @@ import {
   Organisation,
   Schedule,
   Event,
+  TimeSegment,
 } from './models';
 import Creators from './creators';
 import { schedulePerms, eventPerms } from './perms';
@@ -233,6 +234,55 @@ export const scheduleHandler = {
 export const timeSegmentHandler = {
   user(timesegment) {
     return timesegment.getUser();
+  },
+  createTimeSegment(_, args, ctx) {
+    const { scheduleId, status, startTime, endTime } = args.timeSegment;
+    return getAuthenticatedUser(ctx)
+      .then(user =>
+        Schedule.findById(scheduleId).then((schedule) => {
+          if (!schedule) {
+            return Promise.reject(Error('Invalid schedule!'));
+          }
+          return Creators.timeSegment({
+            schedule,
+            status,
+            startTime,
+            endTime,
+            user,
+          });
+        }),
+      );
+  },
+  removeTimeSegment(_, args, ctx) {
+    const { segmentId } = args.timeSegment;
+    return getAuthenticatedUser(ctx)
+      .then(() =>
+        TimeSegment.findById(segmentId).then((segment) => {
+          if (!segment) {
+            return Promise.reject(Error('Invalid segment!'));
+          }
+          return segment.destroy().then((rows) => {
+            if (rows) { return true; }
+            return false;
+          });
+        }),
+      );
+  },
+  editTimeSegment(_, args, ctx) {
+    const { segmentId, status, startTime, endTime } = args.timeSegment;
+    return getAuthenticatedUser(ctx)
+      .then(() =>
+        TimeSegment.findById(segmentId).then((segment) => {
+          if (!segment) {
+            return Promise.reject(Error('Invalid segment!'));
+          }
+          return segment.update({
+            status,
+            startTime,
+            endTime,
+          });
+        }),
+      );
   },
 };
 

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -50,6 +50,8 @@ const EventModel = db.define('event', {
 const ScheduleModel = db.define('schedule', {
   name: { type: Sequelize.STRING },
   details: { type: Sequelize.STRING },
+  startTime: { type: Sequelize.INTEGER },
+  endTime: { type: Sequelize.INTEGER },
 });
 
 const TimeSegmentModel = db.define('timesegment', {

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -135,8 +135,8 @@ export const Resolvers = {
     removeTimeSegment(_, args, ctx) {
       return timeSegmentHandler.removeTimeSegment(_, args, ctx);
     },
-    editTimeSegment(_, args, ctx) {
-      return timeSegmentHandler.editTimeSegment(_, args, ctx);
+    updateTimeSegment(_, args, ctx) {
+      return timeSegmentHandler.updateTimeSegment(_, args, ctx);
     },
   },
 };

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -129,6 +129,15 @@ export const Resolvers = {
     createSchedule(_, args, ctx) {
       return scheduleHandler.createSchedule(_, args, ctx);
     },
+    createTimeSegment(_, args, ctx) {
+      return timeSegmentHandler.createTimeSegment(_, args, ctx);
+    },
+    removeTimeSegment(_, args, ctx) {
+      return timeSegmentHandler.removeTimeSegment(_, args, ctx);
+    },
+    editTimeSegment(_, args, ctx) {
+      return timeSegmentHandler.editTimeSegment(_, args, ctx);
+    },
   },
 };
 

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -34,6 +34,24 @@ export const Schema = [`
     groupId: Int!
   }
 
+  input createTimeSegmentInput {
+    scheduleId: Int!
+    status: String!
+    startTime: Int!
+    endTime: Int!
+  }
+
+  input editTimeSegmentInput {
+    segmentId: Int!
+    status: String!
+    startTime: Int!
+    endTime: Int!
+  }
+
+  input removeTimeSegmentInput {
+    segmentId: Int!
+  }
+
   input AddUserToGroupInput {
     groupId: Int!
   }
@@ -126,10 +144,13 @@ export const Schema = [`
     id: Int!
     name: String!
     details: String!
+    startTime: Int!
+    endTime: Int!
     timeSegments: [TimeSegment]!
   }
 
   type TimeSegment {
+    id: Int!
     schedule: Schedule!
     user: User!
     status: String
@@ -157,6 +178,9 @@ export const Schema = [`
     createUser(user: CreateUserInput!): User
     deleteUser(user: DeleteUserInput!): User
     createSchedule(schedule: CreateScheduleInput!): Schedule
+    createTimeSegment(timeSegment: createTimeSegmentInput!): TimeSegment
+    editTimeSegment(timeSegment: editTimeSegmentInput!): TimeSegment
+    removeTimeSegment(timeSegment: removeTimeSegmentInput!): Boolean
     addUserToGroup(groupUpdate: AddUserToGroupInput!): Group
     removeUserFromGroup(groupUpdate: RemoveUserFromGroupInput!): Boolean
     createOrganisation(organisation: CreateOrganisationInput!): Organisation

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -41,7 +41,7 @@ export const Schema = [`
     endTime: Int!
   }
 
-  input editTimeSegmentInput {
+  input updateTimeSegmentInput {
     segmentId: Int!
     status: String!
     startTime: Int!
@@ -179,7 +179,7 @@ export const Schema = [`
     deleteUser(user: DeleteUserInput!): User
     createSchedule(schedule: CreateScheduleInput!): Schedule
     createTimeSegment(timeSegment: createTimeSegmentInput!): TimeSegment
-    editTimeSegment(timeSegment: editTimeSegmentInput!): TimeSegment
+    updateTimeSegment(timeSegment: updateTimeSegmentInput!): TimeSegment
     removeTimeSegment(timeSegment: removeTimeSegmentInput!): Boolean
     addUserToGroup(groupUpdate: AddUserToGroupInput!): Group
     removeUserFromGroup(groupUpdate: RemoveUserFromGroupInput!): Boolean

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -1,4 +1,5 @@
 import Creators from './creators';
+import distantFuture from './constants';
 
 const nowInUTC = () => {
   const d = new Date();
@@ -57,7 +58,7 @@ export const loadTestData = () =>
               name: 'Wollongong S&W',
               details: 'Weekly storm availability',
               startTime: 0, // ongoing
-              endTime: 0, // ongoing
+              endTime: distantFuture, // ongoing
             }).then(schedule =>
               Creators.timeSegment({
                 status: 'Available',
@@ -72,7 +73,7 @@ export const loadTestData = () =>
               name: 'Wollongong VR',
               details: 'Weekly VR availability',
               startTime: 0, // ongoing
-              endTime: 0, // ongoing
+              endTime: distantFuture, // ongoing
             }),
             Creators.schedule({
               group,
@@ -132,7 +133,7 @@ export const loadTestData = () =>
             name: 'SWR FR Roster',
             details: 'SWR FR availability',
             startTime: 0, // ongoing
-            endTime: 0, // ongoing
+            endTime: distantFuture, // ongoing
           }),
         ]),
         ),

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -1,5 +1,10 @@
 import Creators from './creators';
 
+const nowInGMT = () => {
+  const d = new Date();
+  return Math.round((d.getTime() - 39600) / 1000);
+};
+
 export const loadTestData = () =>
   Creators.organisation({
     name: 'NSW SES',
@@ -51,11 +56,13 @@ export const loadTestData = () =>
               group,
               name: 'Wollongong S&W',
               details: 'Weekly storm availability',
+              startTime: 0, // ongoing
+              endTime: 0, // ongoing
             }).then(schedule =>
               Creators.timeSegment({
                 status: 'Available',
-                startTime: 1511853428,
-                endTime: 1511854428,
+                startTime: nowInGMT() + 3600, // +1 hr
+                endTime: nowInGMT() + (3600 * 2), // +2 hr
                 schedule,
                 user,
               }),
@@ -64,11 +71,15 @@ export const loadTestData = () =>
               group,
               name: 'Wollongong VR',
               details: 'Weekly VR availability',
+              startTime: 0, // ongoing
+              endTime: 0, // ongoing
             }),
             Creators.schedule({
               group,
               name: 'Emergency Services Expo',
               details: '5 people needed for demonstrations on Sunday',
+              startTime: 1512860400, // Sunday 10/12/17 @ 10am AEST in GMT
+              endTime: 1512878400, // Sunday 10/12/17 @ 3pm AEST in GMT
             }),
             Creators.tag({
               name: 'Wollongong City',
@@ -120,6 +131,8 @@ export const loadTestData = () =>
             group,
             name: 'SWR FR Roster',
             details: 'SWR FR availability',
+            startTime: 0, // ongoing
+            endTime: 0, // ongoing
           }),
         ]),
         ),

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -1,8 +1,8 @@
 import Creators from './creators';
 
-const nowInGMT = () => {
+const nowInUTC = () => {
   const d = new Date();
-  return Math.round((d.getTime() - 39600) / 1000);
+  return Math.round(d.getTime() / 1000);
 };
 
 export const loadTestData = () =>
@@ -61,8 +61,8 @@ export const loadTestData = () =>
             }).then(schedule =>
               Creators.timeSegment({
                 status: 'Available',
-                startTime: nowInGMT() + 3600, // +1 hr
-                endTime: nowInGMT() + (3600 * 2), // +2 hr
+                startTime: nowInUTC() + 3600, // +1 hr
+                endTime: nowInUTC() + (3600 * 2), // +2 hr
                 schedule,
                 user,
               }),


### PR DESCRIPTION
Mutations/log/schema for

editTimeSegment - edit existing segment
removeTimeSegment - remove existing segment
createTimeSegment - create new segment

Added start/end time to schedules to support perpetual vs short term schedules.

**NO JEST TESTS AT THIS STAGE DUE TO ASYNC ISSUES, HAVE TESTED EACH QUERY LOCALLY**