### PR TITLE
UI - Schedules cleanup & Inclusion of start/end time and descriptioons

### DIFF
--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -1,0 +1,3 @@
+const distantFuture = 2147483647;
+
+export default distantFuture;

--- a/client/src/graphql/current-user.query.js
+++ b/client/src/graphql/current-user.query.js
@@ -21,6 +21,9 @@ export default gql`
       schedules {
         id
         name
+        details
+        startTime
+        endTime
       }
     }
   }

--- a/client/src/graphql/join-group.mutation.js
+++ b/client/src/graphql/join-group.mutation.js
@@ -13,6 +13,17 @@ export default gql`
          username
          id
        }
+       events {
+         id
+         details
+       }
+       schedules {
+         id
+         name
+         details
+         startTime
+         endTime
+       }
     }
   }
 `;

--- a/client/src/graphql/search-group.query.js
+++ b/client/src/graphql/search-group.query.js
@@ -23,6 +23,8 @@ export default gql`
               id
               name
               details
+              startTime
+              endTime
             }
             events {
               id

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -423,20 +423,23 @@ const joinGroupMutation = graphql(JOIN_GROUP_MUTATION, {
     joinGroupQry: ({ groupId }) =>
       mutate({
         variables: { groupUpdate: { groupId } },
-        update: (store, { data: { addUserToGroup } }) => {
-          // fetch data from the cache
-          const data = store.readQuery({
-            query: CURRENT_USER_QUERY,
-          });
-          // add new data to the cache
-          data.user.groups.push(addUserToGroup);
-
-          // write out cache
-          store.writeQuery({
-            query: CURRENT_USER_QUERY,
-            data,
-          });
-        },
+        refetchQueries: [{
+          query: CURRENT_USER_QUERY,
+        }],
+        // update: (store, { data: { addUserToGroup } }) => {
+        //   // fetch data from the cache
+        //   const data = store.readQuery({
+        //     query: CURRENT_USER_QUERY,
+        //   });
+        //   // add new data to the cache
+        //   data.user.groups.push(addUserToGroup);
+        //   console.log(data, addUserToGroup);
+        //   // write out cache
+        //   store.writeQuery({
+        //     query: CURRENT_USER_QUERY,
+        //     data,
+        //   });
+        // },
       }),
   }),
 });
@@ -446,21 +449,24 @@ const leaveGroupMutation = graphql(LEAVE_GROUP_MUTATION, {
     leaveGroupQry: ({ groupId }) =>
       mutate({
         variables: { groupUpdate: { groupId } },
-        update: (store, { data: { removeUserFromGroup } }) => {
-          if (removeUserFromGroup) {
-          // fetch data from the cache
-            const data = store.readQuery({
-              query: CURRENT_USER_QUERY,
-            });
-            // add new data to the cache
-            data.user.groups = _.filter(data.user.groups, (n => n.id !== groupId));
-            // write out cache
-            store.writeQuery({
-              query: CURRENT_USER_QUERY,
-              data,
-            });
-          }
-        },
+        refetchQueries: [{
+          query: CURRENT_USER_QUERY,
+        }],
+        // update: (store, { data: { removeUserFromGroup } }) => {
+        //   if (removeUserFromGroup) {
+        //   // fetch data from the cache
+        //     const data = store.readQuery({
+        //       query: CURRENT_USER_QUERY,
+        //     });
+        //     // add new data to the cache
+        //     data.user.groups = _.filter(data.user.groups, (n => n.id !== groupId));
+        //     // write out cache
+        //     store.writeQuery({
+        //       query: CURRENT_USER_QUERY,
+        //       data,
+        //     });
+        //   }
+        // },
       }),
   }),
 });

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -56,7 +56,7 @@ const styles = extendAppStyleSheet({
     fontWeight: 'bold',
     fontSize: 18,
   },
-  eventContainer: {
+  groupContainer: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
@@ -66,14 +66,14 @@ const styles = extendAppStyleSheet({
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
-  eventName: {
+  groupName: {
     fontWeight: 'bold',
     flex: 0.7,
   },
-  eventTitleContainer: {
+  groupTitleContainer: {
     flexDirection: 'row',
   },
-  eventTextContainer: {
+  groupTextContainer: {
     flex: 1,
     flexDirection: 'column',
     paddingLeft: 6,
@@ -203,8 +203,9 @@ const ScheduleDisplay = (props) => {
   if (startTime === 0 && endTime === distantFuture) {
     timeText = 'Perpetual Schedule';
   } else {
-    timeText =
-    `${moment.unix(startTime).format('DD/MM/YY, HH:mm:ss')} - ${moment.unix(endTime).format('DD/MM/YY, HH:mm:ss')}`;
+    const startText = moment.unix(startTime).format('DD/MM/YY, HH:mm:ss');
+    const endText = moment.unix(endTime).format('DD/MM/YY, HH:mm:ss');
+    timeText = `${startText} - ${endText}`;
   }
   return (
     <TouchableHighlight key={id}>

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -428,6 +428,7 @@ const joinGroupMutation = graphql(JOIN_GROUP_MUTATION, {
             query: CURRENT_USER_QUERY,
           });
           // add new data to the cache
+          console.log(data.user.groups);
           data.user.groups.push(addUserToGroup);
           console.log(data.user.groups);
 

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import _ from 'lodash';
 import moment from 'moment';
 
+import distantFuture from '../constants';
 import { extendAppStyleSheet } from './style-sheet';
 import SEARCH_GROUP_QUERY from '../graphql/search-group.query';
 import JOIN_GROUP_MUTATION from '../graphql/join-group.mutation';
@@ -199,7 +200,7 @@ EventsDisplay.propTypes = {
 const ScheduleDisplay = (props) => {
   const { id, name, details, startTime, endTime } = props.schedule;
   let timeText = '';
-  if (startTime === 0 && endTime === 0) {
+  if (startTime === 0 && endTime === distantFuture) {
     timeText = 'Perpetual Schedule';
   } else {
     timeText =
@@ -428,9 +429,7 @@ const joinGroupMutation = graphql(JOIN_GROUP_MUTATION, {
             query: CURRENT_USER_QUERY,
           });
           // add new data to the cache
-          console.log(data.user.groups);
           data.user.groups.push(addUserToGroup);
-          console.log(data.user.groups);
 
           // write out cache
           store.writeQuery({

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -56,7 +56,19 @@ const styles = extendAppStyleSheet({
     fontWeight: 'bold',
     fontSize: 18,
   },
-  groupContainer: {
+  groupName: {
+    fontWeight: 'bold',
+    flex: 0.7,
+  },
+  groupTitleContainer: {
+    flexDirection: 'row',
+  },
+  groupTextContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    paddingLeft: 6,
+  },
+  eventContainer: {
     flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
@@ -66,14 +78,14 @@ const styles = extendAppStyleSheet({
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
-  groupName: {
+  eventName: {
     fontWeight: 'bold',
     flex: 0.7,
   },
-  groupTitleContainer: {
+  eventTitleContainer: {
     flexDirection: 'row',
   },
-  groupTextContainer: {
+  eventTextContainer: {
     flex: 1,
     flexDirection: 'column',
     paddingLeft: 6,

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -311,7 +311,6 @@ class Group extends Component {
 
   render() {
     const { loading, user, networkStatus } = this.props;
-
     if (loading || !user) {
       return (
         <View style={[styles.loading, styles.container]}>
@@ -423,23 +422,21 @@ const joinGroupMutation = graphql(JOIN_GROUP_MUTATION, {
     joinGroupQry: ({ groupId }) =>
       mutate({
         variables: { groupUpdate: { groupId } },
-        refetchQueries: [{
-          query: CURRENT_USER_QUERY,
-        }],
-        // update: (store, { data: { addUserToGroup } }) => {
-        //   // fetch data from the cache
-        //   const data = store.readQuery({
-        //     query: CURRENT_USER_QUERY,
-        //   });
-        //   // add new data to the cache
-        //   data.user.groups.push(addUserToGroup);
-        //   console.log(data, addUserToGroup);
-        //   // write out cache
-        //   store.writeQuery({
-        //     query: CURRENT_USER_QUERY,
-        //     data,
-        //   });
-        // },
+        update: (store, { data: { addUserToGroup } }) => {
+          // fetch data from the cache
+          const data = store.readQuery({
+            query: CURRENT_USER_QUERY,
+          });
+          // add new data to the cache
+          data.user.groups.push(addUserToGroup);
+          data.user.schedules = _.merge(data.user.schedules, addUserToGroup.schedules);
+          data.user.events = _.merge(data.user.events, addUserToGroup.events);
+          // write out cache
+          store.writeQuery({
+            query: CURRENT_USER_QUERY,
+            data,
+          });
+        },
       }),
   }),
 });
@@ -452,21 +449,6 @@ const leaveGroupMutation = graphql(LEAVE_GROUP_MUTATION, {
         refetchQueries: [{
           query: CURRENT_USER_QUERY,
         }],
-        // update: (store, { data: { removeUserFromGroup } }) => {
-        //   if (removeUserFromGroup) {
-        //   // fetch data from the cache
-        //     const data = store.readQuery({
-        //       query: CURRENT_USER_QUERY,
-        //     });
-        //     // add new data to the cache
-        //     data.user.groups = _.filter(data.user.groups, (n => n.id !== groupId));
-        //     // write out cache
-        //     store.writeQuery({
-        //       query: CURRENT_USER_QUERY,
-        //       data,
-        //     });
-        //   }
-        // },
       }),
   }),
 });

--- a/client/src/screens/group.screen.js
+++ b/client/src/screens/group.screen.js
@@ -13,6 +13,7 @@ import { graphql, compose } from 'react-apollo';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
 import _ from 'lodash';
+import moment from 'moment';
 
 import { extendAppStyleSheet } from './style-sheet';
 import SEARCH_GROUP_QUERY from '../graphql/search-group.query';
@@ -53,6 +54,56 @@ const styles = extendAppStyleSheet({
   headerName: {
     fontWeight: 'bold',
     fontSize: 18,
+  },
+  eventContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderBottomColor: '#eee',
+    borderBottomWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  eventName: {
+    fontWeight: 'bold',
+    flex: 0.7,
+  },
+  eventTitleContainer: {
+    flexDirection: 'row',
+  },
+  eventTextContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    paddingLeft: 6,
+  },
+  eventText: {
+    color: '#8c8c8c',
+  },
+  scheduleContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: 'white',
+    borderBottomColor: '#eee',
+    borderBottomWidth: 1,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  scheduleName: {
+    fontWeight: 'bold',
+    flex: 0.7,
+  },
+  scheduleTitleContainer: {
+    flexDirection: 'row',
+  },
+  scheduleTextContainer: {
+    flex: 1,
+    flexDirection: 'column',
+    paddingLeft: 6,
+  },
+  scheduleText: {
+    color: '#8c8c8c',
   },
 });
 
@@ -126,14 +177,13 @@ const EventsDisplay = (props) => {
   const { id, name, details } = props.event;
   return (
     <TouchableHighlight key={id}>
-      <View style={styles.groupContainer}>
+      <View style={styles.eventContainer}>
         <Icon name="bullhorn" size={24} color="blue" />
-        <View style={styles.groupTextContainer}>
-          <View style={styles.groupTitleContainer}>
-            <Text style={styles.groupName} numberOfLines={1}>{name}</Text>
+        <View style={styles.eventTextContainer}>
+          <View style={styles.eventTitleContainer}>
+            <Text style={styles.eventName} numberOfLines={1}>{name}</Text>
           </View>
-          <Text style={styles.groupUsername} />
-          <Text style={styles.groupText} numberOfLines={1}>{details}</Text>
+          <Text style={styles.eventText} numberOfLines={1}>{details}</Text>
         </View>
       </View>
     </TouchableHighlight>
@@ -147,17 +197,23 @@ EventsDisplay.propTypes = {
 };
 
 const ScheduleDisplay = (props) => {
-  const { id, name, details } = props.schedule;
+  const { id, name, details, startTime, endTime } = props.schedule;
+  let timeText = '';
+  if (startTime === 0 && endTime === 0) {
+    timeText = 'Perpetual Schedule';
+  } else {
+    timeText =
+    `${moment.unix(startTime).format('DD/MM/YY, HH:mm:ss')} - ${moment.unix(endTime).format('DD/MM/YY, HH:mm:ss')}`;
+  }
   return (
     <TouchableHighlight key={id}>
-      <View style={styles.groupContainer}>
+      <View style={styles.scheduleContainer}>
         <Icon name="calendar" size={24} color="blue" />
-        <View style={styles.groupTextContainer}>
+        <View style={styles.scheduleTextContainer}>
           <View style={styles.groupTitleContainer}>
-            <Text style={styles.groupName} numberOfLines={1}>{name}</Text>
+            <Text style={styles.scheduleName} numberOfLines={1}>{name} - {timeText}</Text>
           </View>
-          <Text style={styles.groupUsername} />
-          <Text style={styles.groupText} numberOfLines={1}>{details}</Text>
+          <Text style={styles.scheduleText} numberOfLines={1}>{details}</Text>
         </View>
       </View>
     </TouchableHighlight>
@@ -167,6 +223,9 @@ ScheduleDisplay.propTypes = {
   schedule: PropTypes.shape({
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
+    details: PropTypes.string,
+    startTime: PropTypes.number.isRequired,
+    endTime: PropTypes.number.isRequired,
   }),
 };
 
@@ -330,6 +389,8 @@ Group.propTypes = {
               id: PropTypes.number.isRequired,
               name: PropTypes.string.isRequired,
               details: PropTypes.string.isRequired,
+              startTime: PropTypes.number.isRequired,
+              endTime: PropTypes.number.isRequired,
             }),
           ),
           events: PropTypes.arrayOf(
@@ -368,6 +429,8 @@ const joinGroupMutation = graphql(JOIN_GROUP_MUTATION, {
           });
           // add new data to the cache
           data.user.groups.push(addUserToGroup);
+          console.log(data.user.groups);
+
           // write out cache
           store.writeQuery({
             query: CURRENT_USER_QUERY,

--- a/client/src/screens/schedules.screen.js
+++ b/client/src/screens/schedules.screen.js
@@ -200,6 +200,7 @@ Schedules.propTypes = {
       PropTypes.shape({
         id: PropTypes.number.isRequired,
         name: PropTypes.string.isRequired,
+        details: PropTypes.string.isRequired,
         startTime: PropTypes.number.isRequired,
         endTime: PropTypes.number.isRequired,
       }),

--- a/client/src/screens/schedules.screen.js
+++ b/client/src/screens/schedules.screen.js
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import moment from 'moment';
 import { extendAppStyleSheet } from './style-sheet';
 import CURRENT_USER_QUERY from '../graphql/current-user.query';
+import distantFuture from '../constants';
 
 const styles = extendAppStyleSheet({
   scheduleContainer: {
@@ -76,7 +77,7 @@ class Schedule extends Component {
   render() {
     const { id, name, details, startTime, endTime } = this.props.schedule;
     let timeText = '';
-    if (startTime === 0 && endTime === 0) {
+    if (startTime === 0 && endTime === distantFuture) {
       timeText = 'Perpetual Schedule';
     } else {
       const startText = moment.unix(startTime).format('DD/MM/YY, HH:mm:ss');

--- a/client/src/screens/schedules.screen.js
+++ b/client/src/screens/schedules.screen.js
@@ -11,7 +11,7 @@ import {
 import { graphql, compose } from 'react-apollo';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
-
+import moment from 'moment';
 import { extendAppStyleSheet } from './style-sheet';
 import CURRENT_USER_QUERY from '../graphql/current-user.query';
 
@@ -74,7 +74,15 @@ class Schedule extends Component {
   }
 
   render() {
-    const { id, name } = this.props.schedule;
+    const { id, name, details, startTime, endTime } = this.props.schedule;
+    let timeText = '';
+    if (startTime === 0 && endTime === 0) {
+      timeText = 'Perpetual Schedule';
+    } else {
+      const startText = moment.unix(startTime).format('DD/MM/YY, HH:mm:ss');
+      const endText = moment.unix(endTime).format('DD/MM/YY, HH:mm:ss');
+      timeText = `${startText} - ${endText}`;
+    }
     return (
       <TouchableHighlight
         key={id}
@@ -84,11 +92,10 @@ class Schedule extends Component {
           <Icon name="calendar-check-o" size={24} color="orange" />
           <View style={styles.scheduleTextContainer}>
             <View style={styles.scheduleTitleContainer}>
-              <Text style={styles.scheduleName}>{`${name}`}</Text>
+              <Text style={styles.scheduleName}>{`${name} - ${timeText}`}</Text>
               <Text style={styles.scheduleLastUpdated} />
             </View>
-            <Text style={styles.scheduleUsername} />
-            <Text style={styles.scheduleText} numberOfLines={1} />
+            <Text style={styles.scheduleText} numberOfLines={1}>{details}</Text>
           </View>
           <Icon
             name="angle-right"
@@ -106,6 +113,9 @@ Schedule.propTypes = {
   schedule: PropTypes.shape({
     id: PropTypes.number,
     name: PropTypes.string,
+    details: PropTypes.string,
+    startTime: PropTypes.number.isRequired,
+    endTime: PropTypes.number.isRequired,
   }),
 };
 
@@ -190,6 +200,8 @@ Schedules.propTypes = {
       PropTypes.shape({
         id: PropTypes.number.isRequired,
         name: PropTypes.string.isRequired,
+        startTime: PropTypes.number.isRequired,
+        endTime: PropTypes.number.isRequired,
       }),
     ),
   }),

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -6,9 +6,9 @@ const nowInUTC = () => {
   return Math.round(d.getTime() / 1000);
 };
 
-const nowInGMT = () => {
+const nowInUTC = () => {
   const d = new Date();
-  return Math.round((d.getTime() - 39600) / 1000);
+  return Math.round(d.getTime() / 1000);
 };
 
 export const loadTestData = () =>

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -6,6 +6,11 @@ const nowInUTC = () => {
   return Math.round(d.getTime() / 1000);
 };
 
+const nowInGMT = () => {
+  const d = new Date();
+  return Math.round((d.getTime() - 39600) / 1000);
+};
+
 export const loadTestData = () =>
   Creators.organisation({
     name: 'NSW SES',

--- a/server/src/test-data.js
+++ b/server/src/test-data.js
@@ -6,11 +6,6 @@ const nowInUTC = () => {
   return Math.round(d.getTime() / 1000);
 };
 
-const nowInUTC = () => {
-  const d = new Date();
-  return Math.round(d.getTime() / 1000);
-};
-
 export const loadTestData = () =>
   Creators.organisation({
     name: 'NSW SES',


### PR DESCRIPTION
Cleaned up the style on the schedules screen.

Added schedule descriptions and start/end time display to the group page and schedules list.

![screenshot 2017-12-07 15 11 31](https://user-images.githubusercontent.com/5799222/33698846-4db379f8-db63-11e7-91b5-1226110c6651.png)
![screenshot 2017-12-07 15 10 49](https://user-images.githubusercontent.com/5799222/33698847-4ddc8546-db63-11e7-9b5f-3f1cb60f8f5e.png)
