### PR TITLE
Reorg of Authentication Area 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -13,7 +13,6 @@
     "apollo-client": "^1.9.3",
     "babel-core": "^6.26.0",
     "buffer": "^5.0.7",
-    "color": "^2.0.0",
     "expo": "^23.0.2",
     "graphql": "^0.11.0",
     "graphql-tag": "^2.5.0",

--- a/client/package.json
+++ b/client/package.json
@@ -1,54 +1,55 @@
 {
-	"name": "Callout",
-	"version": "0.0.1",
-	"private": true,
-	"scripts": {
-		"start": "react-native-scripts start",
-		"test": "jest",
-		"push-ios": "code-push release-react availability-poc ios",
-		"push-android": "code-push release-react availability-poc-android android",
-		"lint": "eslint src"
-	},
-	"dependencies": {
-		"apollo-client": "^1.9.3",
-		"babel-core": "^6.26.0",
-		"buffer": "^5.0.7",
-		"expo": "^23.0.2",
-		"graphql": "^0.11.0",
-		"graphql-tag": "^2.5.0",
-		"immutability-helper": "^2.3.0",
-		"lodash": "^4.17.4",
-		"moment": "^2.18.1",
-		"prop-types": "^15.6.0",
-		"randomcolor": "^0.5.3",
-		"react": "16.0.0",
-		"react-apollo": "^1.4.16",
-		"react-native": "^0.50.4",
-		"react-native-alphabetlistview": "^0.2.0",
-		"react-native-code-push": "^5.2.0-beta",
-		"react-native-maps": "^0.18.2",
-		"react-native-vector-icons": "^4.4.2",
-		"react-navigation": "^1.0.0-beta.11",
-		"react-redux": "^5.0.5",
-		"redux": "^3.7.2",
-		"redux-persist": "^5.4.0",
-		"redux-thunk": "^2.2.0",
-		"seamless-immutable": "^7.1.2",
-		"subscriptions-transport-ws": "^0.9.1"
-	},
-	"devDependencies": {
-		"babel-eslint": "^8.0.2",
-		"babel-jest": "^21.2.0",
-		"babel-preset-react-native": "^4.0.0",
-		"eslint": "^4.11.0",
-		"eslint-config-airbnb": "^16.1.0",
-		"eslint-plugin-import": "^2.8.0",
-		"eslint-plugin-jsx-a11y": "^6.0.2",
-		"eslint-plugin-react": "^7.5.1",
-		"jest": "^21.2.1",
-		"react-test-renderer": "^16.1.1"
-	},
-	"jest": {
-		"preset": "react-native"
-	}
+  "name": "Callout",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "start": "react-native-scripts start",
+    "test": "jest",
+    "push-ios": "code-push release-react availability-poc ios",
+    "push-android": "code-push release-react availability-poc-android android",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "apollo-client": "^1.9.3",
+    "babel-core": "^6.26.0",
+    "buffer": "^5.0.7",
+    "color": "^2.0.0",
+    "expo": "^23.0.2",
+    "graphql": "^0.11.0",
+    "graphql-tag": "^2.5.0",
+    "immutability-helper": "^2.3.0",
+    "lodash": "^4.17.4",
+    "moment": "^2.18.1",
+    "prop-types": "^15.6.0",
+    "randomcolor": "^0.5.3",
+    "react": "16.0.0",
+    "react-apollo": "^1.4.16",
+    "react-native": "^0.50.4",
+    "react-native-alphabetlistview": "^0.2.0",
+    "react-native-code-push": "^5.2.0-beta",
+    "react-native-maps": "^0.18.2",
+    "react-native-vector-icons": "^4.4.2",
+    "react-navigation": "^1.0.0-beta.11",
+    "react-redux": "^5.0.5",
+    "redux": "^3.7.2",
+    "redux-persist": "^5.4.0",
+    "redux-thunk": "^2.2.0",
+    "seamless-immutable": "^7.1.2",
+    "subscriptions-transport-ws": "^0.9.1"
+  },
+  "devDependencies": {
+    "babel-eslint": "^8.0.2",
+    "babel-jest": "^21.2.0",
+    "babel-preset-react-native": "^4.0.0",
+    "eslint": "^4.11.0",
+    "eslint-config-airbnb": "^16.1.0",
+    "eslint-plugin-import": "^2.8.0",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-react": "^7.5.1",
+    "jest": "^21.2.1",
+    "react-test-renderer": "^16.1.1"
+  },
+  "jest": {
+    "preset": "react-native"
+  }
 }

--- a/client/src/components/Alert/Alert.js
+++ b/client/src/components/Alert/Alert.js
@@ -1,0 +1,99 @@
+import React, { Component } from 'react';
+import { TouchableOpacity, View, Animated } from 'react-native';
+import PropTypes from 'prop-types';
+
+import Icon from 'react-native-vector-icons/SimpleLineIcons';
+
+import Colors from './../../themes/Colors';
+import { Text } from '../Text';
+import styles from './styles';
+
+const bottom = -100;
+
+class Alert extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      deltaY: new Animated.Value(0),
+    };
+    this.hide = this.hide.bind(this);
+  }
+  _timeout = false;
+
+  show() {
+    Animated.timing(this.state.deltaY, {
+      toValue: 1,
+      useNativeDriver: true,
+    }).start();
+
+    if (this.timeout) {
+      clearTimeout(this.timeout);
+    }
+
+    this.timeout = setTimeout(() => {
+      this.hide();
+    }, 3000);
+  }
+
+  hide() {
+    Animated.timing(this.state.deltaY, {
+      toValue: 0,
+      useNativeDriver: true,
+    }).start();
+  }
+
+  render() {
+    let title = 'Error';
+    let txtColor = Colors.txtError;
+    let message = 'Server error, something went wrong.';
+    const status = this.props.status || 'error';
+
+    if (status === 'success') {
+      txtColor = Colors.txtSuccess;
+      title = 'Success';
+      message = 'Data submitted successfully.';
+    }
+
+    title = this.props.title || title;
+    message = this.props.message || message;
+
+    return (
+      <Animated.View
+        {...this.props}
+        style={[
+          styles.holder,
+          {
+            transform: [
+              {
+                translateY: this.state.deltaY.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: [0, bottom - 25],
+                }),
+              },
+            ],
+          },
+        ]}
+      >
+        <View style={styles.titleHolder}>
+          <Text type="h5" style={{ color: txtColor }}>
+            {title}
+          </Text>
+          <TouchableOpacity onPress={this.hide}>
+            <Icon name="close" size={20} color={txtColor} />
+          </TouchableOpacity>
+        </View>
+        <Text type="span" style={[styles.message, { color: txtColor }]}>
+          {message}
+        </Text>
+      </Animated.View>
+    );
+  }
+}
+
+Alert.propTypes = {
+  status: PropTypes.string,
+  title: PropTypes.string,
+  message: PropTypes.string,
+};
+
+module.exports = Alert;

--- a/client/src/components/Alert/Alert.js
+++ b/client/src/components/Alert/Alert.js
@@ -17,6 +17,7 @@ class Alert extends Component {
       deltaY: new Animated.Value(0),
     };
     this.hide = this.hide.bind(this);
+    this.show = this.show.bind(this);
   }
   _timeout = false;
 
@@ -96,4 +97,4 @@ Alert.propTypes = {
   message: PropTypes.string,
 };
 
-module.exports = Alert;
+export default Alert;

--- a/client/src/components/Alert/index.js
+++ b/client/src/components/Alert/index.js
@@ -1,0 +1,4 @@
+import Alert from './Alert';
+import styles from './styles';
+
+export { Alert, styles };

--- a/client/src/components/Alert/styles.js
+++ b/client/src/components/Alert/styles.js
@@ -1,0 +1,26 @@
+import { StyleSheet } from 'react-native';
+import Colors from '../../themes/Colors';
+
+const bottom = -100;
+const styles = StyleSheet.create({
+  holder: {
+    left: 25,
+    right: 25,
+    position: 'absolute',
+    bottom,
+    zIndex: 1,
+    padding: 20,
+    paddingTop: 15,
+    borderRadius: 5,
+    backgroundColor: Colors.bgWhite,
+  },
+  titleHolder: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  message: {
+    marginTop: 5,
+  },
+});
+
+export default styles;

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { TouchableOpacity, View, Text } from 'react-native';
+import Icon from 'react-native-vector-icons/SimpleLineIcons';
+
+import styles from './styles';
+
+const Button = ({ title, type, disabled, onPress }) => {
+  const txtType = `${type}Txt`;
+
+  return (
+    <TouchableOpacity
+      style={[styles.default, styles[type] || {}]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      {type === 'submit' && (
+        <Icon style={[styles.defaultTxt, styles[txtType] || {}]} name="arrow-right" size={20} />
+      )}
+      <Text style={styles.defaultText}>{title}</Text>
+    </TouchableOpacity>
+  );
+};
+
+Button.propTypes = {
+  title: PropTypes.string,
+  type: PropTypes.string,
+  disabled: PropTypes.bool,
+  onPress: PropTypes.func,
+};
+
+export default Button;

--- a/client/src/components/Button/Button.js
+++ b/client/src/components/Button/Button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TouchableOpacity, View, Text } from 'react-native';
+import { TouchableOpacity, Text, View } from 'react-native';
 import Icon from 'react-native-vector-icons/SimpleLineIcons';
 
 import styles from './styles';
@@ -9,16 +9,18 @@ const Button = ({ title, type, disabled, onPress }) => {
   const txtType = `${type}Txt`;
 
   return (
-    <TouchableOpacity
-      style={[styles.default, styles[type] || {}]}
-      onPress={onPress}
-      disabled={disabled}
-    >
-      {type === 'submit' && (
-        <Icon style={[styles.defaultTxt, styles[txtType] || {}]} name="arrow-right" size={20} />
-      )}
-      <Text style={styles.defaultText}>{title}</Text>
-    </TouchableOpacity>
+    <View>
+      <TouchableOpacity
+        style={disabled === true ? styles.disabled : styles.normal}
+        onPress={onPress}
+        disabled={disabled}
+      >
+        {type === 'submit' && (
+          <Icon style={[styles.defaultTxt, styles[txtType] || {}]} name="arrow-right" size={20} />
+        )}
+        <Text style={styles.defaultText}>{title}</Text>
+      </TouchableOpacity>
+    </View>
   );
 };
 

--- a/client/src/components/Button/NextButton.js
+++ b/client/src/components/Button/NextButton.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { KeyboardAvoidingView, View, Text } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native';
 
 import { Button } from './';
 

--- a/client/src/components/Button/NextButton.js
+++ b/client/src/components/Button/NextButton.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { KeyboardAvoidingView, View, Text } from 'react-native';
+
+import { Button } from './';
+
+import styles from './styles';
+
+const NextButton = ({ onPress, disabled }) => (
+  <KeyboardAvoidingView behavior="position" style={styles.btnSubmitHolder}>
+    <Button onPress={onPress} type="submit" disabled={disabled} />
+  </KeyboardAvoidingView>
+);
+
+NextButton.propTypes = {
+  onPress: PropTypes.func,
+  disabled: PropTypes.bool,
+};
+
+export default NextButton;

--- a/client/src/components/Button/index.js
+++ b/client/src/components/Button/index.js
@@ -1,0 +1,5 @@
+import Button from './Button';
+import NextButton from './NextButton';
+import styles from './styles';
+
+export { Button, NextButton, styles };

--- a/client/src/components/Button/styles.js
+++ b/client/src/components/Button/styles.js
@@ -1,15 +1,26 @@
 import { StyleSheet } from 'react-native';
 import Colors from '../../themes/Colors';
 
+const defaultStyle = {
+  height: 50,
+  borderRadius: 25,
+  borderWidth: 1,
+  justifyContent: 'center',
+  alignItems: 'center',
+  flexDirection: 'row',
+  width: 50,
+};
+
 const styles = StyleSheet.create({
-  default: {
-    height: 50,
-    borderRadius: 25,
-    borderWidth: 1,
+  normal: {
+    ...defaultStyle,
     borderColor: Colors.bdWhite,
-    justifyContent: 'center',
-    alignItems: 'center',
-    flexDirection: 'row',
+    backgroundColor: Colors.bgWhite,
+  },
+  disabled: {
+    ...defaultStyle,
+    borderColor: Colors.bdDisabled,
+    backgroundColor: Colors.bgDisabled,
   },
   defaultText: {
     color: Colors.txtWhite,

--- a/client/src/components/Button/styles.js
+++ b/client/src/components/Button/styles.js
@@ -1,0 +1,33 @@
+import { StyleSheet } from 'react-native';
+import Colors from '../../themes/Colors';
+
+const styles = StyleSheet.create({
+  default: {
+    height: 50,
+    borderRadius: 25,
+    borderWidth: 1,
+    borderColor: Colors.bdWhite,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+  },
+  defaultText: {
+    color: Colors.txtWhite,
+    fontSize: 20,
+  },
+  btnSubmitHolder: {
+    position: 'absolute',
+    right: 25,
+    bottom: 0,
+    paddingBottom: 25,
+  },
+  submit: {
+    backgroundColor: Colors.bgWhite,
+    width: 50,
+  },
+  submitTxt: {
+    color: Colors.txtMain,
+  },
+});
+
+export default styles;

--- a/client/src/components/Container/Container.js
+++ b/client/src/components/Container/Container.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import { View, TouchableWithoutFeedback } from 'react-native';
 import PropTypes from 'prop-types';
 import styles from './styles';
 
@@ -11,7 +11,7 @@ const Container = ({ children, backgroundColor }) => {
   }
 
   return (
-    <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+    <TouchableWithoutFeedback>
       <View style={containerStyles}>{children}</View>
     </TouchableWithoutFeedback>
   );

--- a/client/src/components/Container/Container.js
+++ b/client/src/components/Container/Container.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { View, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import PropTypes from 'prop-types';
+import styles from './styles';
+
+const Container = ({ children, backgroundColor }) => {
+  const containerStyles = [styles.container];
+
+  if (backgroundColor) {
+    containerStyles.push({ backgroundColor });
+  }
+
+  return (
+    <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
+      <View style={containerStyles}>{children}</View>
+    </TouchableWithoutFeedback>
+  );
+};
+
+Container.propTypes = {
+  children: PropTypes.node,
+  backgroundColor: PropTypes.string,
+};
+
+export default Container;

--- a/client/src/components/Container/Holder.js
+++ b/client/src/components/Container/Holder.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { View } from 'react-native';
+import PropTypes from 'prop-types';
+import styles from './styles';
+
+const Holder = ({ children, backgroundColor }) => {
+  const containerStyles = [styles.holder];
+
+  if (backgroundColor) {
+    containerStyles.push({ backgroundColor });
+  }
+
+  return <View style={containerStyles}>{children}</View>;
+};
+
+Holder.propTypes = {
+  children: PropTypes.node,
+  backgroundColor: PropTypes.string,
+};
+
+export default Holder;

--- a/client/src/components/Container/index.js
+++ b/client/src/components/Container/index.js
@@ -1,0 +1,4 @@
+import Container from './Container';
+import styles from './styles';
+
+export { Container, styles };

--- a/client/src/components/Container/index.js
+++ b/client/src/components/Container/index.js
@@ -1,4 +1,5 @@
 import Container from './Container';
+import Holder from './Holder';
 import styles from './styles';
 
-export { Container, styles };
+export { Container, Holder, styles };

--- a/client/src/components/Container/styles.js
+++ b/client/src/components/Container/styles.js
@@ -1,11 +1,13 @@
 import { StyleSheet } from 'react-native';
-// import Colors from '../../themes/Colors';
+import Colors from '../../themes/Colors';
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    justifyContent: 'center',
-    // backgroundColor: Colors.bgMain,
+    backgroundColor: Colors.bgMain,
+  },
+  holder: {
+    padding: 25,
   },
 });
 

--- a/client/src/components/Container/styles.js
+++ b/client/src/components/Container/styles.js
@@ -1,0 +1,12 @@
+import { StyleSheet } from 'react-native';
+// import Colors from '../../themes/Colors';
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    // backgroundColor: Colors.bgMain,
+  },
+});
+
+export default styles;

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import { View, Text } from 'react-native';
+import { View } from 'react-native';
 import PropTypes from 'prop-types';
 import styles from './styles';
+import { Text } from '../Text';
 
 const Container = ({ title }) => (
   <View style={styles.headerContainer}>
-    <Text style={styles.header}>{title}</Text>
+    <Text type="h1White">{title}</Text>
   </View>
 );
 

--- a/client/src/components/Header/Header.js
+++ b/client/src/components/Header/Header.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import PropTypes from 'prop-types';
+import styles from './styles';
+
+const Container = ({ title }) => (
+  <View style={styles.headerContainer}>
+    <Text style={styles.header}>{title}</Text>
+  </View>
+);
+
+Container.propTypes = {
+  title: PropTypes.string,
+};
+
+export default Container;

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -1,0 +1,4 @@
+import Header from './Header';
+import styles from './styles';
+
+export { Header, styles };

--- a/client/src/components/Header/styles.js
+++ b/client/src/components/Header/styles.js
@@ -1,0 +1,15 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  headerContainer: {
+    marginBottom: 24,
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  header: {
+    fontSize: 42,
+    fontWeight: '100',
+  },
+});
+
+export default styles;

--- a/client/src/components/NavBar/NavBar.js
+++ b/client/src/components/NavBar/NavBar.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { TouchableOpacity, View } from 'react-native';
+import PropTypes from 'prop-types';
+import Icon from 'react-native-vector-icons/SimpleLineIcons';
+
+import { Text } from '../Text';
+import styles from './styles';
+
+const NavBar = ({ onPressBack, rightLinkText, onPressRightLink }) => {
+  let btnBack = null;
+  let btnRight = null;
+
+  if (onPressBack != null) {
+    btnBack = (
+      <TouchableOpacity style={styles.btnback} onPress={onPressBack}>
+        <Icon name="arrow-left" style={styles.icon} size={16} />
+      </TouchableOpacity>
+    );
+  }
+
+  if (rightLinkText != null && onPressRightLink != null) {
+    btnRight = (
+      <TouchableOpacity onPress={onPressRightLink}>
+        <Text type="h5White">{rightLinkText}</Text>
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <View>
+      <View style={styles.bar}>
+        <View style={styles.barLeft}>{btnBack}</View>
+        <View style={styles.barCentre} />
+        <View style={styles.barRight}>{btnRight}</View>
+      </View>
+    </View>
+  );
+};
+
+NavBar.propTypes = {
+  onPressBack: PropTypes.func,
+  rightLinkText: PropTypes.string,
+  onPressRightLink: PropTypes.func,
+};
+
+export default NavBar;

--- a/client/src/components/NavBar/index.js
+++ b/client/src/components/NavBar/index.js
@@ -1,0 +1,4 @@
+import NavBar from './NavBar';
+import styles from './styles';
+
+export { NavBar, styles };

--- a/client/src/components/NavBar/styles.js
+++ b/client/src/components/NavBar/styles.js
@@ -1,0 +1,34 @@
+import { StyleSheet } from 'react-native';
+import Colors from '../../themes/Colors';
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    height: 45,
+  },
+  barLeft: {
+    width: 75,
+  },
+  barCentre: {
+    flex: 1,
+  },
+  barRight: {
+    width: 75,
+    alignItems: 'flex-end',
+    marginRight: 10,
+    marginTop: 20,
+  },
+  text: {
+    color: Colors.txtWhite,
+    fontWeight: '700',
+  },
+  icon: {
+    color: Colors.txtWhite,
+  },
+  btnback: {
+    marginLeft: 10,
+    marginTop: 20,
+  },
+});
+
+export default styles;

--- a/client/src/components/Text/Text.js
+++ b/client/src/components/Text/Text.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import styles from './styles';
+
+const TextCustom = ({ children, type, style }) => {
+  const textType = type || {};
+  const textStyle = { style: [styles.default, styles[textType], style || {}] };
+  const props = Object.assign({}, this.props, textStyle);
+
+  return <Text {...props}>{children}</Text>;
+};
+
+TextCustom.propTypes = {
+  children: PropTypes.node,
+  type: PropTypes.string,
+  style: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+};
+
+module.exports = TextCustom;

--- a/client/src/components/Text/index.js
+++ b/client/src/components/Text/index.js
@@ -1,0 +1,4 @@
+import Text from './Text';
+import styles from './styles';
+
+export { Text, styles };

--- a/client/src/components/Text/styles.js
+++ b/client/src/components/Text/styles.js
@@ -1,0 +1,44 @@
+import { StyleSheet } from 'react-native';
+import Colors from '../../themes/Colors';
+
+const h6 = { fontSize: 13 };
+const h5 = { fontSize: 16 };
+const h4 = { fontSize: 18 };
+const h3 = { fontSize: 25 };
+const h1 = { fontSize: 32 };
+const styles = StyleSheet.create({
+  default: {
+    color: Colors.txtDark,
+    fontSize: 16,
+  },
+  spanWhite: {
+    color: Colors.txtWhite,
+  },
+  h6,
+  h6White: {
+    ...h6,
+    color: Colors.txtWhite,
+  },
+  h5,
+  h5White: {
+    ...h5,
+    color: Colors.txtWhite,
+  },
+  h4,
+  h4White: {
+    ...h4,
+    color: Colors.txtWhite,
+  },
+  h3,
+  h3White: {
+    ...h3,
+    color: Colors.txtWhite,
+  },
+  h1,
+  h1White: {
+    ...h1,
+    color: Colors.txtWhite,
+  },
+});
+
+export default styles;

--- a/client/src/components/TextInput/Input.js
+++ b/client/src/components/TextInput/Input.js
@@ -9,31 +9,29 @@ import styles from './styles';
 const Input = (props) => {
   const { title, value, valid, placeholder, type, onChangeText } = props;
 
-  let typeProps = {};
-  switch (type) {
-    case 'username':
-      typeProps = {
-        autoCapitalize: 'none',
-        autoCorrect: false,
-        returnKeyType: 'next',
-      };
-      break;
-    case 'email':
-      typeProps = {
-        autoCapitalize: 'none',
-        autoCorrect: false,
-        keyboardType: 'email-address',
-        returnKeyType: 'next',
-      };
-      break;
-    case 'password':
-      typeProps = {
-        secureTextEntry: true,
-      };
-      break;
-    default:
-      break;
+  const propsForType = {
+    username: {
+      autoCapitalize: 'none',
+      autoCorrect: false,
+      returnKeyType: 'next',
+    },
+    email: {
+      autoCapitalize: 'none',
+      autoCorrect: false,
+      keyboardType: 'email-address',
+      returnKeyType: 'next',
+    },
+    password: {
+      secureTextEntry: true,
+    },
+  };
+
+  let typeProps = propsForType[type];
+
+  if (typeof typeProps === 'undefined') {
+    typeProps = {};
   }
+
   return (
     <View style={styles.defaultHolder}>
       {title && <Text style={styles.defaultText}>{title.toUpperCase()}</Text>}

--- a/client/src/components/TextInput/Input.js
+++ b/client/src/components/TextInput/Input.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View, Text, TextInput } from 'react-native';
+import PropTypes from 'prop-types';
+import styles from './styles';
+
+const Input = (props) => {
+  const { title, value, placeholder, type, onChangeText } = props;
+
+  let typeProps = {};
+  switch (type) {
+    case 'email':
+      typeProps = {
+        autoCapitalize: 'none',
+        autoCorrect: false,
+        keyboardType: 'email-address',
+        returnKeyType: 'next',
+      };
+      break;
+    case 'password':
+      typeProps = {
+        secureTextEntry: true,
+      };
+      break;
+    default:
+      break;
+  }
+  return (
+    <View>
+      {title && <Text>{title}</Text>}
+      <View style={styles.inputHolder}>
+        <TextInput
+          onChangeText={onChangeText}
+          {...typeProps}
+          value={value}
+          placeholder={placeholder}
+          underlineColorAndroid="rgba(0,0,0,0)"
+          style={styles.default}
+        />
+      </View>
+    </View>
+  );
+};
+
+Input.propTypes = {
+  type: PropTypes.string,
+  title: PropTypes.string,
+  value: PropTypes.string,
+  placeholder: PropTypes.string,
+  onChangeText: PropTypes.func,
+};
+
+export default Input;

--- a/client/src/components/TextInput/Input.js
+++ b/client/src/components/TextInput/Input.js
@@ -1,13 +1,23 @@
 import React from 'react';
 import { View, Text, TextInput } from 'react-native';
 import PropTypes from 'prop-types';
+
+import Icon from 'react-native-vector-icons/Octicons';
+
 import styles from './styles';
 
 const Input = (props) => {
-  const { title, value, placeholder, type, onChangeText } = props;
+  const { title, value, valid, placeholder, type, onChangeText } = props;
 
   let typeProps = {};
   switch (type) {
+    case 'username':
+      typeProps = {
+        autoCapitalize: 'none',
+        autoCorrect: false,
+        returnKeyType: 'next',
+      };
+      break;
     case 'email':
       typeProps = {
         autoCapitalize: 'none',
@@ -25,8 +35,8 @@ const Input = (props) => {
       break;
   }
   return (
-    <View>
-      {title && <Text>{title}</Text>}
+    <View style={styles.defaultHolder}>
+      {title && <Text style={styles.defaultText}>{title.toUpperCase()}</Text>}
       <View style={styles.inputHolder}>
         <TextInput
           onChangeText={onChangeText}
@@ -36,6 +46,7 @@ const Input = (props) => {
           underlineColorAndroid="rgba(0,0,0,0)"
           style={styles.default}
         />
+        {valid && <Icon name="check" size={20} style={styles.validIcon} />}
       </View>
     </View>
   );
@@ -45,6 +56,7 @@ Input.propTypes = {
   type: PropTypes.string,
   title: PropTypes.string,
   value: PropTypes.string,
+  valid: PropTypes.bool,
   placeholder: PropTypes.string,
   onChangeText: PropTypes.func,
 };

--- a/client/src/components/TextInput/index.js
+++ b/client/src/components/TextInput/index.js
@@ -1,0 +1,4 @@
+import Input from './Input';
+import styles from './styles';
+
+export { Input, styles };

--- a/client/src/components/TextInput/styles.js
+++ b/client/src/components/TextInput/styles.js
@@ -1,0 +1,13 @@
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  default: {
+    height: 40,
+    borderRadius: 4,
+    marginVertical: 6,
+    padding: 6,
+    backgroundColor: 'rgba(0,0,0,0.2)',
+  },
+});
+
+export default styles;

--- a/client/src/components/TextInput/styles.js
+++ b/client/src/components/TextInput/styles.js
@@ -1,12 +1,33 @@
 import { StyleSheet } from 'react-native';
+import Colors from '../../themes/Colors';
 
 const styles = StyleSheet.create({
   default: {
-    height: 40,
-    borderRadius: 4,
-    marginVertical: 6,
-    padding: 6,
-    backgroundColor: 'rgba(0,0,0,0.2)',
+    height: 50,
+    justifyContent: 'center',
+    alignItems: 'center',
+    flexDirection: 'row',
+    color: Colors.txtWhite,
+    fontWeight: '700',
+    fontSize: 24,
+    flex: 1,
+  },
+  defaultHolder: {
+    borderBottomWidth: 1,
+    borderColor: Colors.bdWhite,
+    marginBottom: 25,
+  },
+  defaultText: {
+    color: Colors.txtWhite,
+    fontWeight: '700',
+  },
+  inputHolder: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  validIcon: {
+    color: Colors.txtWhite,
+    paddingLeft: 10,
   },
 });
 

--- a/client/src/graphql/current-user.query.js
+++ b/client/src/graphql/current-user.query.js
@@ -23,8 +23,10 @@ export default gql`
         id
         name
         details
-        startTime
-        endTime
+        timeSegments {
+          startTime
+          endTime
+        }
       }
     }
   }

--- a/client/src/navigation.js
+++ b/client/src/navigation.js
@@ -1,8 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { addNavigationHelpers, StackNavigator, TabNavigator, NavigationActions } from 'react-navigation';
+import {
+  addNavigationHelpers,
+  StackNavigator,
+  TabNavigator,
+  NavigationActions,
+} from 'react-navigation';
 import { connect } from 'react-redux';
 import { REHYDRATE } from 'redux-persist';
+
+import StackAuth from './screens/auth/StackAuth';
 
 import Home from './screens/home.screen';
 import Groups from './screens/groups.screen';
@@ -14,7 +21,6 @@ import Settings from './screens/settings.screen';
 import NewGroup from './screens/new-group.screen';
 import SearchGroup from './screens/search-groups.screen';
 import EventDetail from './screens/event-detail.screen';
-
 
 const tabBarConfiguration = {
   tabBarPosition: 'bottom',
@@ -33,31 +39,35 @@ const tabBarConfiguration = {
 };
 
 // tabs in main screen
-const MainScreenNavigator = TabNavigator({
-  Home: { screen: Home },
-  Groups: { screen: Groups },
-  Schedules: { screen: Schedules },
-  Events: { screen: Events },
-  Settings: { screen: Settings },
-}, tabBarConfiguration);
+const MainScreenNavigator = TabNavigator(
+  {
+    Home: { screen: Home },
+    Groups: { screen: Groups },
+    Schedules: { screen: Schedules },
+    Events: { screen: Events },
+    Settings: { screen: Settings },
+  },
+  tabBarConfiguration,
+);
 
-const AppNavigator = StackNavigator({
-  Main: { screen: MainScreenNavigator },
-  Signin: { screen: Signin },
-  NewGroup: { screen: NewGroup },
-  SearchGroup: { screen: SearchGroup },
-  Group: { screen: Group },
-  Event: { screen: EventDetail },
-}, {
-  mode: 'modal',
-});
+const AppNavigator = StackNavigator(
+  {
+    Main: { screen: MainScreenNavigator },
+    Signin: { screen: Signin },
+    NewGroup: { screen: NewGroup },
+    SearchGroup: { screen: SearchGroup },
+    Group: { screen: Group },
+    Event: { screen: EventDetail },
+  },
+  {
+    mode: 'modal',
+  },
+);
 
 // reducer initialization code
 const firstAction = AppNavigator.router.getActionForPathAndParams('Main');
 const tempNavState = AppNavigator.router.getStateForAction(firstAction);
-const initialNavState = AppNavigator.router.getStateForAction(
-  tempNavState,
-);
+const initialNavState = AppNavigator.router.getStateForAction(tempNavState);
 
 // reducer code
 export const navigationReducer = (state = initialNavState, action) => {
@@ -96,12 +106,20 @@ export const navigationReducer = (state = initialNavState, action) => {
 
 const AppWithNavigationState = (props) => {
   const { dispatch, nav } = props;
+
+  console.log(nav);
+
+  if (!props.auth.username) {
+    return <StackAuth />;
+  }
+
   return <AppNavigator navigation={addNavigationHelpers({ dispatch, state: nav })} />;
 };
 
 AppWithNavigationState.propTypes = {
   dispatch: PropTypes.func.isRequired,
   nav: PropTypes.shape().isRequired,
+  auth: PropTypes.shape().isRequired,
 };
 
 const mapStateToProps = ({ auth, nav }) => ({

--- a/client/src/navigation.js
+++ b/client/src/navigation.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { addNavigationHelpers, StackNavigator, TabNavigator } from 'react-navigation';
 import { connect } from 'react-redux';
-// import { REHYDRATE } from 'redux-persist';
 
 import StackAuth from './screens/auth/StackAuth';
 
@@ -69,30 +68,6 @@ const initialNavState = AppNavigator.router.getStateForAction(tempNavState);
 export const navigationReducer = (state = initialNavState, action) => {
   let nextState;
   switch (action.type) {
-    /*
-    case REHYDRATE:
-      // convert persisted data to Immutable and confirm rehydration
-      if (!action.payload || !action.payload.auth || !action.payload.auth.token) {
-        const { routes, index } = state;
-        if (routes[index].routeName !== 'Signin') {
-          nextState = AppNavigator.router.getStateForAction(
-            NavigationActions.navigate({ routeName: 'Signin' }),
-            state,
-          );
-        }
-      }
-      break;
-    case 'LOGOUT': {
-      const { routes, index } = state;
-      if (routes[index].routeName !== 'Signin') {
-        nextState = AppNavigator.router.getStateForAction(
-          NavigationActions.navigate({ routeName: 'Signin' }),
-          state,
-        );
-      }
-      break;
-    }
-      */
     default:
       nextState = AppNavigator.router.getStateForAction(action, state);
       break;

--- a/client/src/navigation.js
+++ b/client/src/navigation.js
@@ -1,22 +1,18 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import {
-  addNavigationHelpers,
-  StackNavigator,
-  TabNavigator,
-  NavigationActions,
-} from 'react-navigation';
+import { addNavigationHelpers, StackNavigator, TabNavigator } from 'react-navigation';
 import { connect } from 'react-redux';
-import { REHYDRATE } from 'redux-persist';
+// import { REHYDRATE } from 'redux-persist';
 
 import StackAuth from './screens/auth/StackAuth';
+
+import { Container } from './components/Container';
 
 import Home from './screens/home.screen';
 import Groups from './screens/groups.screen';
 import Group from './screens/group.screen';
 import Events from './screens/events.screen';
 import Schedules from './screens/schedules.screen';
-import Signin from './screens/signin.screen';
 import Settings from './screens/settings.screen';
 import NewGroup from './screens/new-group.screen';
 import SearchGroup from './screens/search-groups.screen';
@@ -53,7 +49,7 @@ const MainScreenNavigator = TabNavigator(
 const AppNavigator = StackNavigator(
   {
     Main: { screen: MainScreenNavigator },
-    Signin: { screen: Signin },
+    // Signin: { screen: Signin },
     NewGroup: { screen: NewGroup },
     SearchGroup: { screen: SearchGroup },
     Group: { screen: Group },
@@ -73,6 +69,7 @@ const initialNavState = AppNavigator.router.getStateForAction(tempNavState);
 export const navigationReducer = (state = initialNavState, action) => {
   let nextState;
   switch (action.type) {
+    /*
     case REHYDRATE:
       // convert persisted data to Immutable and confirm rehydration
       if (!action.payload || !action.payload.auth || !action.payload.auth.token) {
@@ -95,6 +92,7 @@ export const navigationReducer = (state = initialNavState, action) => {
       }
       break;
     }
+      */
     default:
       nextState = AppNavigator.router.getStateForAction(action, state);
       break;
@@ -107,7 +105,9 @@ export const navigationReducer = (state = initialNavState, action) => {
 const AppWithNavigationState = (props) => {
   const { dispatch, nav } = props;
 
-  console.log(nav);
+  if (props.auth.loading) {
+    return <Container />;
+  }
 
   if (!props.auth.username) {
     return <StackAuth />;

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -30,6 +30,8 @@ class SignIn extends Component {
   }
 
   onPressLogin() {
+    Keyboard.dismiss();
+
     const { username, password } = this.state;
     const { deviceUuid } = this.props.local;
 
@@ -47,7 +49,6 @@ class SignIn extends Component {
           status: 'Login Error',
           errorMessage: error.message,
         });
-        Keyboard.dismiss();
         this.popRef.show();
       });
   }

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -1,8 +1,11 @@
 import React, { Component } from 'react';
+import { Keyboard } from 'react-native';
 import { connect } from 'react-redux';
 import { graphql, compose } from 'react-apollo';
 
 import PropTypes from 'prop-types';
+
+import { setCurrentUser } from '../../state/auth.actions';
 
 import { NextButton } from '../../components/Button';
 import { Container, Holder } from '../../components/Container';
@@ -30,27 +33,21 @@ class SignIn extends Component {
     const { username, password } = this.state;
     const { deviceUuid } = this.props.local;
 
-    this.setState({ loading: true });
-
     this.props
       .login({ username, password, deviceUuid })
       .then(({ data: { login: user } }) => {
-        /*
         const ourUser = {
           username: user.username,
           token: user.authToken,
         };
         this.props.dispatch(setCurrentUser(ourUser));
-        */
-
-        this.setState({ loading: false });
       })
       .catch((error) => {
         this.setState({
-          loading: false,
           status: 'Login Error',
           errorMessage: error.message,
         });
+        Keyboard.dismiss();
         this.popRef.show();
       });
   }
@@ -97,7 +94,10 @@ class SignIn extends Component {
             type="password"
           />
         </Holder>
-        <NextButton onPress={this.onPressLogin} disabled={this.state.loading} />
+        <NextButton
+          onPress={this.onPressLogin}
+          disabled={!(this.state.usernameValid && this.state.passwordValid)}
+        />
         <Alert
           ref={(el) => {
             this.popRef = el;
@@ -118,6 +118,7 @@ SignIn.propTypes = {
     deviceUuid: PropTypes.string,
   }),
   login: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
 };
 
 const login = graphql(LOGIN_MUTATION, {

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -26,16 +26,9 @@ class SignIn extends Component {
       passwordValid: false,
     };
     this.popupRef = null;
-<<<<<<< HEAD
   }
 
   onPressLogin = () => {
-=======
-    this.onPressLogin = this.onPressLogin.bind(this);
-  }
-
-  onPressLogin() {
->>>>>>> 51afef3bf5ae5c1c41454416043c02f3413769d9
     Keyboard.dismiss();
 
     const { username, password } = this.state;
@@ -57,11 +50,7 @@ class SignIn extends Component {
         });
         this.popRef.show();
       });
-<<<<<<< HEAD
   };
-=======
-  }
->>>>>>> 51afef3bf5ae5c1c41454416043c02f3413769d9
 
   onChangePassword = (value) => {
     let passwordValid = false;
@@ -83,7 +72,6 @@ class SignIn extends Component {
     });
   };
 
-<<<<<<< HEAD
   onSignUp = () => {
     this.props.navigation.navigate('SignUp');
   };
@@ -92,15 +80,6 @@ class SignIn extends Component {
     return (
       <Container>
         <NavBar rightLinkText="Sign Up" onPressRightLink={this.onSignUp} />
-=======
-  render() {
-    return (
-      <Container>
-        <NavBar
-          rightLinkText="Sign Up"
-          onPressRightLink={() => this.props.navigation.navigate('SignUp')}
-        />
->>>>>>> 51afef3bf5ae5c1c41454416043c02f3413769d9
         <Holder>
           <Header title="Login" />
           <Input

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -1,0 +1,155 @@
+import React, { Component } from 'react';
+import {
+  KeyboardAvoidingView,
+  View,
+  Text,
+  StyleSheet,
+  Button,
+  TouchableOpacity,
+} from 'react-native';
+import { connect } from 'react-redux';
+import { graphql, compose } from 'react-apollo';
+
+import PropTypes from 'prop-types';
+
+import { Container } from '../../components/Container';
+import { Header } from '../../components/Header';
+import { Input } from '../../components/TextInput';
+
+import LOGIN_MUTATION from '../../graphql/login.mutation';
+
+const styles = StyleSheet.create({
+  inputContainer: {
+    marginBottom: 20,
+    paddingHorizontal: 50,
+  },
+  loadingContainer: {
+    left: 0,
+    right: 0,
+    top: 0,
+    bottom: 0,
+    position: 'absolute',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  switchContainer: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    marginTop: 12,
+  },
+  switchAction: {
+    paddingHorizontal: 4,
+    color: 'blue',
+  },
+  submit: {
+    marginVertical: 6,
+  },
+});
+
+class SignIn extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: '',
+      password: '',
+      loading: false,
+    };
+    this.onPressLogin = this.onPressLogin.bind(this);
+    this.onPressSignUp = this.onPressSignUp.bind(this);
+  }
+
+  onPressLogin() {
+    const { username, password } = this.state;
+
+    this.setState({
+      loading: true,
+    });
+
+    const { deviceUuid } = this.props.local;
+
+    this.props
+      .login({ username, password, deviceUuid })
+      .then(({ data: { login: user } }) => {
+        const ourUser = {
+          username: user.username,
+          token: user.authToken,
+        };
+        // this.props.dispatch(setCurrentUser(ourUser));
+        this.setState({
+          loading: false,
+        });
+      })
+      .catch((error) => {
+        this.setState({
+          loading: false,
+        });
+        /*
+        Alert.alert(`${capitalizeFirstLetter(this.state.view)} error`, error.message, [
+          { text: 'OK', onPress: () => console.log('OK pressed') }, // eslint-disable-line no-console
+          {
+            text: 'Forgot password',
+            onPress: () => console.log('Forgot Pressed'),
+            style: 'cancel',
+          }, // eslint-disable-line no-console
+        ]);
+        */
+      });
+  }
+
+  onPressSignUp() {
+    this.props.navigation.navigate('SignUp');
+  }
+
+  render() {
+    return (
+      <Container>
+        <KeyboardAvoidingView behavior="padding">
+          <Header title="Login" type="password" />
+          <View style={styles.inputContainer}>
+            <Input placeholder="Username" onChangeText={username => this.setState({ username })} />
+            <Input
+              placeholder="Password"
+              onChangeText={password => this.setState({ password })}
+              type="password"
+            />
+          </View>
+          <Button style={styles.submit} title="Login" onPress={this.onPressLogin} />
+          <View style={styles.switchContainer}>
+            <Text>New to Availability?</Text>
+            <TouchableOpacity onPress={this.onPressSignUp}>
+              <Text style={styles.switchAction}>Sign Up</Text>
+            </TouchableOpacity>
+          </View>
+        </KeyboardAvoidingView>
+      </Container>
+    );
+  }
+}
+
+SignIn.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func,
+  }),
+  local: PropTypes.shape({
+    deviceUuid: PropTypes.string,
+  }),
+  dispatch: PropTypes.func.isRequired,
+  login: PropTypes.func.isRequired,
+};
+
+const login = graphql(LOGIN_MUTATION, {
+  props: ({ mutate }) => ({
+    login: ({ username, password, deviceUuid }) =>
+      mutate({
+        variables: { user: { username, password, deviceUuid } },
+      }),
+  }),
+});
+
+const mapStateToProps = ({ auth, local }) => ({
+  auth,
+  local,
+});
+
+export default compose(login, connect(mapStateToProps))(SignIn);

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -26,10 +26,9 @@ class SignIn extends Component {
       passwordValid: false,
     };
     this.popupRef = null;
-    this.onPressLogin = this.onPressLogin.bind(this);
   }
 
-  onPressLogin() {
+  onPressLogin = () => {
     Keyboard.dismiss();
 
     const { username, password } = this.state;
@@ -51,7 +50,7 @@ class SignIn extends Component {
         });
         this.popRef.show();
       });
-  }
+  };
 
   onChangePassword = (value) => {
     let passwordValid = false;

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -72,13 +72,14 @@ class SignIn extends Component {
     });
   };
 
+  onSignUp = () => {
+    this.props.navigation.navigate('SignUp');
+  };
+
   render() {
     return (
       <Container>
-        <NavBar
-          rightLinkText="Sign Up"
-          onPressRightLink={() => this.props.navigation.navigate('SignUp')}
-        />
+        <NavBar rightLinkText="Sign Up" onPressRightLink={this.onSignUp} />
         <Holder>
           <Header title="Login" />
           <Input

--- a/client/src/screens/auth/SignUp.js
+++ b/client/src/screens/auth/SignUp.js
@@ -30,6 +30,7 @@ class SignUp extends Component {
   }
 
   onPressSignUp() {
+    Keyboard.dismiss();
     const { deviceUuid } = this.props.local;
     const { username, password, email } = this.state;
     this.props
@@ -46,7 +47,6 @@ class SignUp extends Component {
           status: 'Sign Up Error',
           errorMessage: error.message,
         });
-        Keyboard.dismiss();
         this.popRef.show();
       });
   }

--- a/client/src/screens/auth/SignUp.js
+++ b/client/src/screens/auth/SignUp.js
@@ -81,7 +81,6 @@ class SignUp extends Component {
     });
   };
 
-<<<<<<< HEAD
   onPressBack = () => {
     this.props.navigation.goBack();
   };
@@ -90,12 +89,6 @@ class SignUp extends Component {
     return (
       <Container>
         <NavBar onPressBack={this.onPressBack} />
-=======
-  render() {
-    return (
-      <Container>
-        <NavBar onPressBack={() => this.props.navigation.goBack()} />
->>>>>>> 51afef3bf5ae5c1c41454416043c02f3413769d9
         <Holder>
           <Header title="Sign Up" />
           <Input

--- a/client/src/screens/auth/SignUp.js
+++ b/client/src/screens/auth/SignUp.js
@@ -1,0 +1,21 @@
+import React, { Component } from 'react';
+import { Text, View } from 'react-native';
+import { connect } from 'react-redux';
+import { compose } from 'react-apollo';
+
+class SignUp extends Component {
+  render() {
+    return (
+      <View>
+        <Text>Auth Index</Text>
+      </View>
+    );
+  }
+}
+
+const mapStateToProps = ({ auth, local }) => ({
+  auth,
+  local,
+});
+
+export default compose(connect(mapStateToProps))(SignUp);

--- a/client/src/screens/auth/SignUp.js
+++ b/client/src/screens/auth/SignUp.js
@@ -81,10 +81,14 @@ class SignUp extends Component {
     });
   };
 
+  onPressBack = () => {
+    this.props.navigation.goBack();
+  };
+
   render() {
     return (
       <Container>
-        <NavBar onPressBack={() => this.props.navigation.goBack()} />
+        <NavBar onPressBack={this.onPressBack} />
         <Holder>
           <Header title="Sign Up" />
           <Input

--- a/client/src/screens/auth/SignUp.js
+++ b/client/src/screens/auth/SignUp.js
@@ -1,14 +1,88 @@
 import React, { Component } from 'react';
-import { Text, View } from 'react-native';
 import { connect } from 'react-redux';
 import { compose } from 'react-apollo';
+import PropTypes from 'prop-types';
+
+import { Container, Holder } from '../../components/Container';
+import { Header } from '../../components/Header';
+import { Input } from '../../components/TextInput';
+import { NavBar } from '../../components/NavBar';
+import { NextButton } from '../../components/Button';
 
 class SignUp extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      username: '',
+      password: '',
+      email: '',
+      usernameValid: false,
+      passwordValid: false,
+      emailValid: false,
+      loading: false,
+    };
+    this.onPressSignUp = this.onPressSignUp.bind(this);
+  }
+
+  onPressSignUp() {}
+
+  onChangeEmail = (value) => {
+    let emailValid = false;
+    if (value.indexOf('@') !== -1) emailValid = true;
+
+    this.setState({
+      email: value,
+      emailValid,
+    });
+  };
+
+  onChangePassword = (value) => {
+    let passwordValid = false;
+    if (value.length > 5) passwordValid = true;
+
+    this.setState({
+      password: value,
+      passwordValid,
+    });
+  };
+
+  onChangeUsername = (value) => {
+    let usernameValid = false;
+    if (value.length > 5) usernameValid = true;
+
+    this.setState({
+      username: value,
+      usernameValid,
+    });
+  };
+
   render() {
     return (
-      <View>
-        <Text>Auth Index</Text>
-      </View>
+      <Container>
+        <NavBar onPressBack={() => this.props.navigation.goBack()} />
+        <Holder>
+          <Header title="Sign Up" />
+          <Input
+            title="Username"
+            onChangeText={this.onChangeUsername}
+            valid={this.state.usernameValid}
+            type="username"
+          />
+          <Input
+            title="Password"
+            onChangeText={this.onChangePassword}
+            valid={this.state.passwordValid}
+            type="password"
+          />
+          <Input
+            title="Email"
+            onChangeText={this.onChangeEmail}
+            valid={this.state.emailValid}
+            type="email"
+          />
+        </Holder>
+        <NextButton onPress={this.onPressSignUp} disabled={this.state.loading} />
+      </Container>
     );
   }
 }
@@ -17,5 +91,11 @@ const mapStateToProps = ({ auth, local }) => ({
   auth,
   local,
 });
+
+SignUp.propTypes = {
+  navigation: PropTypes.shape({
+    goBack: PropTypes.func,
+  }),
+};
 
 export default compose(connect(mapStateToProps))(SignUp);

--- a/client/src/screens/auth/StackAuth.js
+++ b/client/src/screens/auth/StackAuth.js
@@ -22,4 +22,4 @@ const StackAuth = StackNavigator(
   },
 );
 
-module.exports = StackAuth;
+export default StackAuth;

--- a/client/src/screens/auth/StackAuth.js
+++ b/client/src/screens/auth/StackAuth.js
@@ -1,0 +1,25 @@
+import { StackNavigator } from 'react-navigation';
+
+import SignIn from './SignIn';
+import SignUp from './SignUp';
+
+const options = {
+  header: null,
+};
+
+const StackAuth = StackNavigator(
+  {
+    SignIn: {
+      screen: SignIn,
+    },
+    SignUp: {
+      screen: SignUp,
+    },
+  },
+  {
+    initialRouteName: 'SignIn',
+    navigationOptions: options,
+  },
+);
+
+module.exports = StackAuth;

--- a/client/src/screens/groups.screen.js
+++ b/client/src/screens/groups.screen.js
@@ -1,13 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import {
-  FlatList,
-  ActivityIndicator,
-  Button,
-  Text,
-  TouchableHighlight,
-  View,
-} from 'react-native';
+import { FlatList, ActivityIndicator, Button, Text, TouchableHighlight, View } from 'react-native';
 import { graphql, compose } from 'react-apollo';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
@@ -88,10 +81,13 @@ class Group extends Component {
           <Icon name="group" size={24} color="orange" />
           <View style={styles.groupTextContainer}>
             <View style={styles.groupTitleContainer}>
-              <Text style={styles.groupName} numberOfLines={1}>{name}</Text>
+              <Text style={styles.groupName} numberOfLines={1}>
+                {name}
+              </Text>
               <Text style={styles.groupLastUpdated}>{id}</Text>
             </View>
-            <Text style={styles.groupText} numberOfLines={1}>{tags}
+            <Text style={styles.groupText} numberOfLines={1}>
+              {tags}
             </Text>
           </View>
           <Icon name="angle-right" size={24} color="#8c8c8c" />
@@ -124,9 +120,7 @@ Group.propTypes = {
 class Groups extends Component {
   static navigationOptions = {
     title: 'Groups',
-    tabBarIcon: ({ tintColor }) => (
-      <Icon size={24} name="group" color={tintColor} />
-    ),
+    tabBarIcon: ({ tintColor }) => <Icon size={24} name="group" color={tintColor} />,
   };
 
   constructor(props) {
@@ -162,6 +156,7 @@ class Groups extends Component {
 
   render() {
     const { loading, user, networkStatus } = this.props;
+
     // render loading placeholder while we fetch messages
     if (loading || !user) {
       return (
@@ -235,7 +230,10 @@ Groups.propTypes = {
 const userQuery = graphql(CURRENT_USER_QUERY, {
   skip: ownProps => !ownProps.auth || !ownProps.auth.token,
   props: ({ data: { loading, networkStatus, refetch, user } }) => ({
-    loading, networkStatus, refetch, user,
+    loading,
+    networkStatus,
+    refetch,
+    user,
   }),
 });
 
@@ -243,7 +241,4 @@ const mapStateToProps = ({ auth }) => ({
   auth,
 });
 
-export default compose(
-  connect(mapStateToProps),
-  userQuery,
-)(Groups);
+export default compose(connect(mapStateToProps), userQuery)(Groups);

--- a/client/src/screens/schedules.screen.js
+++ b/client/src/screens/schedules.screen.js
@@ -146,7 +146,6 @@ class Schedules extends Component {
     if (loading || !user) {
       return (
         <View style={[styles.loading, styles.container]}>
-          <Text>Activity {(user === null).toString()}</Text>
           <ActivityIndicator />
         </View>
       );

--- a/client/src/screens/schedules.screen.js
+++ b/client/src/screens/schedules.screen.js
@@ -1,13 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import {
-  FlatList,
-  ActivityIndicator,
-  Button,
-  Text,
-  TouchableHighlight,
-  View,
-} from 'react-native';
+import { FlatList, ActivityIndicator, Button, Text, TouchableHighlight, View } from 'react-native';
 import { graphql, compose } from 'react-apollo';
 import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
@@ -85,10 +78,7 @@ class Schedule extends Component {
       timeText = `${startText} - ${endText}`;
     }
     return (
-      <TouchableHighlight
-        key={id}
-        onPress={this.goToSchedule}
-      >
+      <TouchableHighlight key={id} onPress={this.goToSchedule}>
         <View style={styles.scheduleContainer}>
           <Icon name="calendar-check-o" size={24} color="orange" />
           <View style={styles.scheduleTextContainer}>
@@ -96,13 +86,11 @@ class Schedule extends Component {
               <Text style={styles.scheduleName}>{`${name} - ${timeText}`}</Text>
               <Text style={styles.scheduleLastUpdated} />
             </View>
-            <Text style={styles.scheduleText} numberOfLines={1}>{details}</Text>
+            <Text style={styles.scheduleText} numberOfLines={1}>
+              {details}
+            </Text>
           </View>
-          <Icon
-            name="angle-right"
-            size={24}
-            color="#8c8c8c"
-          />
+          <Icon name="angle-right" size={24} color="#8c8c8c" />
         </View>
       </TouchableHighlight>
     );
@@ -158,6 +146,7 @@ class Schedules extends Component {
     if (loading || !user) {
       return (
         <View style={[styles.loading, styles.container]}>
+          <Text>Activity {(user === null).toString()}</Text>
           <ActivityIndicator />
         </View>
       );
@@ -212,7 +201,10 @@ Schedules.propTypes = {
 const userQuery = graphql(CURRENT_USER_QUERY, {
   skip: ownProps => !ownProps.auth || !ownProps.auth.token,
   props: ({ data: { loading, networkStatus, refetch, user } }) => ({
-    loading, networkStatus, refetch, user,
+    loading,
+    networkStatus,
+    refetch,
+    user,
   }),
 });
 
@@ -220,7 +212,4 @@ const mapStateToProps = ({ auth }) => ({
   auth,
 });
 
-export default compose(
-  connect(mapStateToProps),
-  userQuery,
-)(Schedules);
+export default compose(connect(mapStateToProps), userQuery)(Schedules);

--- a/client/src/screens/settings.screen.js
+++ b/client/src/screens/settings.screen.js
@@ -1,13 +1,7 @@
 /* global navigator */
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import {
-  ActivityIndicator,
-  Alert,
-  Button,
-  Text,
-  View,
-} from 'react-native';
+import { ActivityIndicator, Alert, Button, Text, View } from 'react-native';
 import { connect } from 'react-redux';
 import { graphql, compose } from 'react-apollo';
 import Icon from 'react-native-vector-icons/FontAwesome';
@@ -101,17 +95,15 @@ class Settings extends Component {
 
   updateLocation() {
     const reportError = (error) => {
-      Alert.alert(
-        'Error updating location',
-        error.message,
-      );
+      Alert.alert('Error updating location', error.message);
     };
 
     // `navigator` is a browser polyfill and does not need to be imported
     navigator.geolocation.getCurrentPosition(
       (position) => {
         const { latitude, longitude } = position.coords;
-        this.props.updateLocation({ locationLat: latitude, locationLon: longitude })
+        this.props
+          .updateLocation({ locationLat: latitude, locationLon: longitude })
           .then((result) => {
             const success = result.data.updateLocation;
             console.log(`Updated location: ${latitude},${longitude} (${success})`);
@@ -148,14 +140,8 @@ class Settings extends Component {
       <View style={styles.container}>
         <View style={styles.userContainer}>
           <View style={styles.userInner}>
-            <Icon
-              name="user"
-              size={50}
-              style={styles.userImage}
-            />
-            <Text style={styles.inputInstructions}>
-              {user.username}
-            </Text>
+            <Icon name="user" size={50} style={styles.userImage} />
+            <Text style={styles.inputInstructions}>{user.username}</Text>
           </View>
         </View>
         <Text style={styles.emailHeader}>Email Account</Text>
@@ -184,7 +170,8 @@ const userQuery = graphql(CURRENT_USER_QUERY, {
   skip: ownProps => !ownProps.auth || !ownProps.auth.token,
   options: ({ auth }) => ({ variables: { id: auth.id }, fetchPolicy: 'cache-only' }),
   props: ({ data: { loading, user } }) => ({
-    loading, user,
+    loading,
+    user,
   }),
 });
 
@@ -192,8 +179,4 @@ const mapStateToProps = ({ auth }) => ({
   auth,
 });
 
-export default compose(
-  connect(mapStateToProps),
-  userQuery,
-  updateLocationMutation,
-)(Settings);
+export default compose(connect(mapStateToProps), userQuery, updateLocationMutation)(Settings);

--- a/client/src/themes/Colors.js
+++ b/client/src/themes/Colors.js
@@ -4,7 +4,7 @@ const Colors = {
   txtDescription: '#757575',
   txtDark: '#484848',
   txtWhite: '#ffffff',
-  txtError: '#fb642d',
+  txtError: '#FF5A5F',
   txtSuccess: '#25ce66',
   txtLink: '#007AFF',
 
@@ -12,11 +12,13 @@ const Colors = {
   bgMainDark: '#4F6D7A', // For screens > auth
   bgMainRed: '#FF5A5F',
   bgWhite: '#ffffff',
-  bgError: '#fb642d',
+  bgDisabled: '#D3D3D3',
+  bgError: '#FF5A5F',
   bgChat: '#f1f1f1',
 
   bdMain: '#00a699',
   bdWhite: '#ffffff',
+  bdDisabled: '#D3D3D3',
   bdLine: '#dddddd',
   bdInput: '#cbcbcb',
 };

--- a/client/src/themes/Colors.js
+++ b/client/src/themes/Colors.js
@@ -1,0 +1,24 @@
+const Colors = {
+  txtMain: '#00a699',
+  txtMainRed: '#FF5A5F',
+  txtDescription: '#757575',
+  txtDark: '#484848',
+  txtWhite: '#ffffff',
+  txtError: '#fb642d',
+  txtSuccess: '#25ce66',
+  txtLink: '#007AFF',
+
+  bgMain: '#00a699',
+  bgMainDark: '#4F6D7A', // For screens > auth
+  bgMainRed: '#FF5A5F',
+  bgWhite: '#ffffff',
+  bgError: '#fb642d',
+  bgChat: '#f1f1f1',
+
+  bdMain: '#00a699',
+  bdWhite: '#ffffff',
+  bdLine: '#dddddd',
+  bdInput: '#cbcbcb',
+};
+
+export default Colors;

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1361,7 +1361,7 @@ color-string@^1.5.2:
     color-name "^1.0.0"
     simple-swizzle "^0.2.2"
 
-color@^2.0.1:
+color@^2.0.0, color@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color/-/color-2.0.1.tgz#e4ed78a3c4603d0891eba5430b04b86314f4c839"
   dependencies:


### PR DESCRIPTION
- Moved authentication to it's own StackNavigator and folder
- Added new dumb components for better organisation and maintainability:
-- Alert : a validation animation component that appears at bottom of screen.
-- Button : customised button with option for inbuilt visual validation
-- Container : base holder for all screens
-- Header : base header for use in screens - makes use of Text component
-- NavBar : custom navbar for complete control over top of screen (only used in auth screens so far)
-- Text : custom text component for rendering predefined text options
-- TextInput : custom display of text input controls - added default underline style
- Styles from containers (screens) removed and moved into the before mentioned dumb components.
- Added /themes/colors.js for an easy colour reference. Future possibility to store these at an organisation level. 
- Changed Navigation to only load the Auth stack initially - fixes an issue where you would see the home screen and then login over the top on slower devices