### PR TITLE
Split unit tests and integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ cache: yarn
 env:
   - COMPONENT=client MODE=lint
   - COMPONENT=server MODE=lint
-  - COMPONENT=server MODE=test
+  - COMPONENT=server MODE=test-integration
+  - COMPONENT=server MODE=test-unit
 script: bash travis.sh

--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,8 @@
     "serve": "node dist/main.js",
     "deploy-heroku": "cd .. && git push heroku $(git subtree split --prefix server master):master --force",
     "lint": "eslint src tests",
-    "test": "jest"
+    "test-integration": "jest tests/",
+    "test-unit": "jest --testPathIgnorePatterns '^<rootDir>/tests/'"
   },
   "devDependencies": {
     "eslint": "^4.4.1",

--- a/travis.sh
+++ b/travis.sh
@@ -6,7 +6,7 @@ cd "$COMPONENT"
 echo "Installing dependencies for $COMPONENT..."
 yarn
 
-if test "$COMPONENT" == "server" -a "$MODE" == "test"
+if test "$COMPONENT" == "server" -a "$MODE" == "test-integration"
 then
   echo "Building server..."
   yarn run build


### PR DESCRIPTION
* So that travis executes them separately
* Once we add coverage we can track the source of the coverage separately
* Now the server only runs in the background for integration tests