### PR TITLE
Fix flaky integration test

### DIFF
--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -363,7 +363,9 @@ export const groupHandler = {
         }
         return user.getGroups({ where: { id: groupId } }).then((existing) => {
           if (existing.length) {
-            return Promise.reject(Error('Already a member!'));
+            return Promise.reject(
+              Error(`${user.id} is already a member of ${groupId}!`),
+            );
           }
           return group.addUser(user).then(() => group);
         });

--- a/server/tests/common.js
+++ b/server/tests/common.js
@@ -30,4 +30,22 @@ export const itReturnsFailure = (response) => {
   }));
 };
 
+export const itReturnsSuccessSync = (response) => {
+  it('returns success', () => {
+    if (response.errors) {
+      // eslint-disable-next-line no-console
+      console.log(response.errors[0].message);
+    }
+    expect(response.success).toBe(true);
+    expect(response.status).toBe(200);
+  });
+};
+
+export const itReturnsFailureSync = (response) => {
+  it('returns failure', () => {
+    expect(response.success).not.toBe(true);
+    expect(response.status).toBe(200);
+  });
+};
+
 export default run;


### PR DESCRIPTION
* One test conflicts with another because they manipulate the same group.
* Switch to using group ID 1 instead
* Use async/await to synchronously run the join/leave group test
* Better debug logging on the server