### PR TITLE
Deploy master branch automatically to heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,20 @@ env:
   - COMPONENT=server MODE=lint
   - COMPONENT=server MODE=test-integration
   - COMPONENT=server MODE=test-unit
+
 script: bash travis.sh
+
+before_deploy:
+- cd server/dist
+
+jobs:
+  include:
+    - stage: deploy
+      env: COMPONENT=server MODE=build
+      deploy:
+        provider: heroku
+        skip_cleanup: true
+        app: ses-availability-api
+        on: master
+        api_key:
+          secure: lQeTIxRHSTTxOwTCd93DjWweDsGeZTD9VVqulNTPijwggEcE+hCXTLW6h15mv52FK/ikBXwUI0y7Y+Ot8mNTJspitw4bQVOHPbXZTAoti2Jy/4gHe+vtqXZW6GvvibuI6hePGRBum2lVTaCO3LPyMM397Em/ziCpPC45XM8IQdNhIpP4gBrq/x6Qrs4SsD3NlYDxDbyn2bhP0mYP4GGfdFJ0WiLEUL9xsHQ2H77z14FMSX9H65G7wul3O0xOga+4nK+T/eoL3drNydT2KPCdIV1nP4xxfA6b17gy2L1o03xolGH2+dF9iGBh8DrxF/6KLsAOdjMQWzfROoqxsCQlj+sr2rVzDEZXbBDSZQZDGlUzUI8lWfYO32bwZ29jk4rserLJnhbIq5HYVw8LrAQVHcUtfF0yJNZFUc3DJUOeV7NZKW0q4iPCisd4OkqopdhOj+XIfAcYc1wRZMmyhQMSPyscVWo0fgWju+T20xaEDoPYWCDpvk7dF/RqUDlGAjTjr/wgZ2LeO9Ko6W89UuGiLIMKJyWIdotBmBz5TdkPD4ZoDQrJaUhzUprhzUSFTqTA7CHicgUAddrSxYkrDsU9bsNEyBFljSwSoQ6iRe6D+KOOHdBBlJ7PkOOpxq7Hqv0PtBMjRfb9cQhWLiqslN29pAiYdxN0E8w6NA3efdUqMu8=

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,1 +1,1 @@
-web: yarn run build && yarn run serve
+web: node main.js

--- a/server/package.json
+++ b/server/package.json
@@ -9,9 +9,8 @@
   "license": "MIT",
   "scripts": {
     "start": "nodemon --watch src src/main.js --exec babel-node",
-    "build": "babel src -d dist",
+    "build": "bash scripts/build.sh",
     "serve": "node dist/main.js",
-    "deploy-heroku": "cd .. && git push heroku $(git subtree split --prefix server master):master --force",
     "lint": "eslint src tests",
     "test-integration": "jest tests/ && codecov -F integration",
     "test-unit": "jest --testPathIgnorePatterns '^<rootDir>/(tests|dist)/' && codecov -F unittests",

--- a/server/scripts/build.sh
+++ b/server/scripts/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script is made to build a self-contained dist/ directory that contains
+# a package.json ready for the nodejs buildpack on heroku but you could also
+# run it elswhere by running: yarn && node main.js
+
+echo "Transpiling with babel..."
+babel src -d dist --ignore '__tests__'
+
+for i in package.json yarn.lock Procfile
+do
+  echo "Copying metadata ($i)..."
+  cp "$i" "dist/$i"
+done


### PR DESCRIPTION
* Use travis build stages to ensure the tests pass before we push.
* New build.sh script to transpile and bundle.
* We ship only the transpiled source, `package.json`, `yarn.lock` and `Procfile` to heroku which should allow for faster dyno start times.
* No longer doing weird git subtree stuff - just upload tarball direct from travis.