### PR TITLE
Cache user ID as well as username

### DIFF
--- a/client/src/graphql/signup.mutation.js
+++ b/client/src/graphql/signup.mutation.js
@@ -4,7 +4,6 @@ export default gql`
   mutation signup($user: SignupInput!) {
     signup(user: $user) {
       id
-      email
       username
       authToken
     }

--- a/client/src/screens/auth/SignIn.js
+++ b/client/src/screens/auth/SignIn.js
@@ -38,6 +38,7 @@ class SignIn extends Component {
       .login({ username, password, deviceUuid })
       .then(({ data: { login: user } }) => {
         const ourUser = {
+          id: user.id,
           username: user.username,
           token: user.authToken,
         };

--- a/client/src/screens/auth/SignUp.js
+++ b/client/src/screens/auth/SignUp.js
@@ -37,6 +37,7 @@ class SignUp extends Component {
       .signup({ username, email, password, deviceUuid })
       .then(({ data: { signup: user } }) => {
         const ourUser = {
+          id: user.id,
           username: user.username,
           token: user.authToken,
         };


### PR DESCRIPTION
* Remove email from query - this might change so we should not cache it.
* This is so we can globally know which user record is the currently logged in
  user..