### PR TITLE
Store location data with the event response

### DIFF
--- a/server/src/models.js
+++ b/server/src/models.js
@@ -58,6 +58,9 @@ export const defineModels = (db) => {
     detail: { type: Sequelize.STRING },
     destination: { type: Sequelize.STRING },
     eta: { type: Sequelize.INTEGER },
+    locationLatitude: { type: Sequelize.FLOAT },
+    locationLongitude: { type: Sequelize.FLOAT },
+    locationTime: { type: Sequelize.INTEGER },
   });
 
   // users <-> groups (many-to-many)

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -133,6 +133,9 @@ export const Schema = [`
     user: User!
     status: String!
     detail: String!
+    locationLatitude: Float
+    locationLongitude: Float
+    locationUpdate: Int
     destination: String!
     eta: Int!
   }


### PR DESCRIPTION
* Originally I had planned to store this denormalized so that you would only
  need to update it in one place but I believe now instead that we should just
  update each place that it is to be used. Reasoning:
  * This makes checking permissions easier - if you can view the EventResponse
    you should be able to see the user's location.
  * Realistically you're only ever going to be submitting your location to a
    handful of events at the most so this duplication isn't much.
  * This gives the person submitting the location data the ability to control
    which events it goes to. In reality we'll probably make it go to all active
    events but in the future this might change.