### PR TITLE
Rudimentary 5s refresh for event details

### DIFF
--- a/client/src/screens/event-detail.screen.js
+++ b/client/src/screens/event-detail.screen.js
@@ -195,6 +195,14 @@ EventResponse.propTypes = {
 };
 
 class EventDetail extends Component {
+  componentDidMount() {
+    this.timer = setInterval(this.onRefresh, 5000); // 5s
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timer);
+  }
+
   onRefresh = () => {
     // NYI
     this.props.refetch();


### PR DESCRIPTION
based off of `sdunster.event_response`