### PR TITLE
Event markers server code

### DIFF
--- a/server/src/__tests__/creators.js
+++ b/server/src/__tests__/creators.js
@@ -217,3 +217,32 @@ describe('create eventResponse', () => {
     expect(result.userId).toBe(user.id);
   });
 });
+
+describe('create eventMarker', () => {
+  const name = 'test';
+  const detail = 'test';
+  const icon = 'test';
+  const locationLatitude = '123.456789';
+  const locationLongitude = '123.456789';
+  const event = { id: 123895 };
+
+
+  it('rejects due to missing event', async () => {
+    await expect(creators.eventMarker({ })).rejects.toThrow();
+  });
+
+  it('returns a eventMarker', async () => {
+    const result = await creators.eventMarker({
+      name,
+      detail,
+      icon,
+      locationLatitude,
+      locationLongitude,
+      event,
+    });
+
+    expect(result.id).toBeDefined();
+    expect(result.name).toBe(name);
+    expect(result.eventId).toBe(event.id);
+  });
+});

--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -4,7 +4,7 @@ import bcrypt from 'bcrypt';
 export const getCreators = (models) => {
   const {
     Organisation, Group, User, Capability, Tag, Device, Event,
-    Schedule, TimeSegment, EventResponse,
+    Schedule, TimeSegment, EventResponse, EventMarker,
   } = models;
 
   return {
@@ -161,6 +161,19 @@ export const getCreators = (models) => {
         locationLongitude,
         locationTime,
         userId: user.id,
+        eventId: event.id,
+      });
+    },
+    eventMarker: ({ name, detail, icon, locationLatitude, locationLongitude, event }) => {
+      if (!event || !event.id) {
+        return Promise.reject(Error('Must pass event'));
+      }
+      return EventMarker.create({
+        name,
+        detail,
+        icon,
+        locationLatitude,
+        locationLongitude,
         eventId: event.id,
       });
     },

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -321,6 +321,9 @@ export const getHandlers = ({ models, creators: Creators }) => {
       responses(event) {
         return event.getEventresponses();
       },
+      eventMarkers(event) {
+        return event.getEventmarkers();
+      },
       setResponse(args, ctx) {
         const {
           id,

--- a/server/src/models-mock.js
+++ b/server/src/models-mock.js
@@ -67,6 +67,14 @@ export const defineModels = () => {
     eta: 1514860289,
   });
 
+  const EventMarkerModel = db.define('eventmarker', {
+    name: 'marker1',
+    detail: 'mock marker',
+    icon: 'marker1',
+    locationLatitude: '123.456789',
+    locationLongitude: '123.456789',
+  });
+
   // users <-> groups (many-to-many)
   UserModel.belongsToMany(GroupModel, { through: 'group_user' });
   GroupModel.belongsToMany(UserModel, { through: 'group_user' });
@@ -113,6 +121,10 @@ export const defineModels = () => {
   TimeSegmentModel.belongsTo(UserModel);
   UserModel.hasMany(TimeSegmentModel);
 
+  // event marker locations belong to an event
+  EventMarkerModel.belongsTo(EventModel);
+  EventModel.hasMany(EventMarkerModel);
+
   // event responses belong to a combination of user/event
   EventResponseModel.belongsTo(EventModel);
   EventModel.hasMany(EventResponseModel);
@@ -136,6 +148,7 @@ export const defineModels = () => {
     Device: db.models.device,
     Event: db.models.event,
     EventResponse: db.models.eventresponse,
+    EventMarker: db.models.eventmarker,
     Schedule: db.models.schedule,
     TimeSegment: db.models.timesegment,
   };

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -64,6 +64,14 @@ export const defineModels = (db) => {
     locationTime: { type: Sequelize.INTEGER },
   });
 
+  const EventMarkerModel = db.define('eventmarker', {
+    name: { type: Sequelize.STRING },
+    detail: { type: Sequelize.STRING },
+    icon: { type: Sequelize.STRING },
+    locationLatitude: { type: Sequelize.FLOAT },
+    locationLongitude: { type: Sequelize.FLOAT },
+  });
+
   // users <-> groups (many-to-many)
   UserModel.belongsToMany(GroupModel, { through: 'group_user' });
   GroupModel.belongsToMany(UserModel, { through: 'group_user' });
@@ -116,6 +124,10 @@ export const defineModels = (db) => {
   EventResponseModel.belongsTo(UserModel);
   UserModel.hasMany(EventResponseModel);
 
+  // event marker locations belong to an event
+  EventMarkerModel.belongsTo(EventModel);
+  EventModel.hasMany(EventMarkerModel);
+
   // tags belong to one organisation for now
   TagModel.belongsTo(OrganisationModel);
   OrganisationModel.hasMany(TagModel);
@@ -133,6 +145,7 @@ export const defineModels = (db) => {
     Device: db.models.device,
     Event: db.models.event,
     EventResponse: db.models.eventresponse,
+    EventMarker: db.models.eventmarker,
     Schedule: db.models.schedule,
     TimeSegment: db.models.timesegment,
   };

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -71,6 +71,9 @@ export const getResolvers = (handlers) => {
       responses(eventt, args, ctx) {
         return eventHandler.responses(eventt, args, ctx);
       },
+      eventMarkers(event, args, ctx) {
+        return eventHandler.eventMarkers(event, args, ctx);
+      },
     },
     EventResponse: {
       user(response, args, ctx) {

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -146,6 +146,7 @@ export const Schema = [`
     details: String!
     group: Group!
     responses: [EventResponse]!
+    eventMarkers: [EventMarker]
   }
 
   type EventResponse {
@@ -158,6 +159,15 @@ export const Schema = [`
     locationTime: Int
     destination: String!
     eta: Int!
+  }
+
+  type EventMarker {
+    event: Event!
+    name: String
+    detail: String
+    icon: String
+    locationLatitude: Float!
+    locationLongitude: Float!
   }
 
   type Schedule {

--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -241,6 +241,22 @@ export const EVENTS = [
     name: 'VR at Gerringong Falls',
     details: '2 climbers stranded 50m from top of cliff.',
     group: 'Kiama',
+    eventMarkers: [
+      {
+        name: 'lhq',
+        detail: 'Local Head Quarters',
+        icon: 'lhq',
+        locationLatitude: -34.6643156,
+        locationLongitude: 150.8438914,
+      },
+      {
+        name: 'scene',
+        detail: 'scene',
+        icon: 'scene',
+        locationLatitude: -34.66828,
+        locationLongitude: 150.85219,
+      },
+    ],
     responses: [
       {
         user: 'test',
@@ -286,6 +302,29 @@ export const EVENTS = [
     name: 'RCR - Princes Highway, Gerringong',
     details: '2 car MVA. Head on collision. 3 people trapped.',
     group: 'Kiama',
+    eventMarkers: [
+      {
+        name: 'lhq',
+        detail: 'Local Head Quarters',
+        icon: 'lhq',
+        locationLatitude: -34.6643156,
+        locationLongitude: 150.8438914,
+      },
+      {
+        name: 'scene',
+        detail: 'scene',
+        icon: 'scene',
+        locationLatitude: -34.7297649,
+        locationLongitude: 150.8249098,
+      },
+      {
+        name: 'landing',
+        detail: 'Helo landing site',
+        icon: 'helo',
+        locationLatitude: -34.7310698,
+        locationLongitude: 150.821659,
+      },
+    ],
     responses: [
       {
         user: 'kiama1',
@@ -331,6 +370,22 @@ export const EVENTS = [
     name: 'FR - WEBB STREET, NORTH PARRAMATTA NSW 2151',
     details: 'APPROX 2 VEH SUBMERGED IN STREET AA WHICH IS CURRENTLY FLOODED JUST OVER WHEEL HEIGHT ON A STANDARD VEH. UNKNOWN IF ANY PERSONS OB. TREE DOWN AND NO WIRES DOWN. NFI',
     group: 'Parramatta',
+    eventMarkers: [
+      {
+        name: 'lhq',
+        detail: 'Local Head Quarters',
+        icon: 'lhq',
+        locationLatitude: -33.7986904,
+        locationLongitude: 150.9952783,
+      },
+      {
+        name: 'scene',
+        detail: 'scene',
+        icon: 'scene',
+        locationLatitude: -33.8031162,
+        locationLongitude: 151.0169367,
+      },
+    ],
     responses: [
       {
         user: 'parramatta1',

--- a/server/src/test-data/load.js
+++ b/server/src/test-data/load.js
@@ -111,12 +111,31 @@ const createEventResponse = (Creators, event, response, users) => {
   });
 };
 
+const createEventMarker = (Creators, event, marker) => {
+  const {
+    name,
+    detail,
+    icon,
+    locationLatitude,
+    locationLongitude,
+  } = marker;
+  return Creators.eventMarker({
+    name,
+    detail,
+    icon,
+    locationLatitude,
+    locationLongitude,
+    event,
+  });
+};
+
 const createEvent = (Creators, event, groups, users) => {
   // create an event from EVENTS. Add each event response as well.
   const group = groups[event.group];
-  const { name, details, responses } = event;
+  const { name, details, responses, eventMarkers } = event;
   return Creators.event({ name, details, group })
     .then(e => Promise.all(
+      eventMarkers.map(em => createEventMarker(Creators, e, em)),
       responses.map(r => createEventResponse(Creators, e, r, users)),
     ));
 };


### PR DESCRIPTION
Server side code for creating event map markers to facilitate drawing map markers for events.

allows any number of markers to be tied to an event with the intention that the client will render these on the live map.

```
   {
                "name": "RCR - Princes Highway, Gerringong",
                "eventMarkers": [
                  {
                    "name": "lhq",
                    "detail": "Local Head Quarters",
                    "icon": "lhq",
                    "locationLatitude": -34.6643156,
                    "locationLongitude": 150.8438914
                  },
                  {
                    "name": "scene",
                    "detail": "scene",
                    "icon": "scene",
                    "locationLatitude": -34.7297649,
                    "locationLongitude": 150.8249098
                  },
                  {
                    "name": "landing",
                    "detail": "Helo landing site",
                    "icon": "helo",
                    "locationLatitude": -34.7310698,
                    "locationLongitude": 150.821659
                  }
                ]
              }
```