### PR TITLE
Add start/end time field to events

### DIFF
--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -1,5 +1,7 @@
 import bcrypt from 'bcrypt';
 
+import { DISTANT_FUTURE } from './constants';
+
 // returns a set of creators bound to the given models
 export const getCreators = (models) => {
   const {
@@ -37,6 +39,8 @@ export const getCreators = (models) => {
         sourceIdentifier,
         permalink,
         groupId: group.id,
+        startTime: (new Date()).getTime() / 1000,
+        endTime: DISTANT_FUTURE, // no end time
       });
     },
 

--- a/server/src/models-mock.js
+++ b/server/src/models-mock.js
@@ -46,7 +46,8 @@ export const defineModels = () => {
     details: 'Details of test event',
     sourceIdentifier: '123-456',
     permalink: 'https://jobsystem.com/jobs/123456',
-
+    startTime: 1514860289,
+    endTime: 1514860289 + (60 * 60),
   });
 
   const ScheduleModel = db.define('schedule', {

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -40,6 +40,8 @@ export const defineModels = (db) => {
     details: { type: Sequelize.STRING },
     sourceIdentifier: { type: Sequelize.STRING },
     permalink: { type: Sequelize.STRING },
+    startTime: { type: Sequelize.INTEGER },
+    endTime: { type: Sequelize.INTEGER },
   });
 
   const ScheduleModel = db.define('schedule', {

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -157,6 +157,8 @@ export const Schema = [
     group: Group!
     responses: [EventResponse]!
     eventLocations: [EventLocation]
+    startTime: Int!
+    endTime: Int!
   }
 
   type EventResponse {


### PR DESCRIPTION
* To track the time that the event began.
* Events begin with endTime set to `DISTANT_FUTURE` - no end time set.