### PR TITLE
platform specific endpoint url

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,5 +1,10 @@
+import { Platform } from 'react-native';
+
+
 export const GRAPHQL_ENDPOINT_PROD = 'https://ses-availability-api.herokuapp.com/graphql';
-export const GRAPHQL_ENDPOINT_LOCAL = 'http://localhost:8080/graphql';
+export const GRAPHQL_ENDPOINT_LOCAL = Platform.OS === 'ios' ?
+  'http://localhost:8080/graphql' :
+  'http://192.168.56.1:8080/graphql';
 
 export const GRAPHQL_ENDPOINT = __DEV__ ? GRAPHQL_ENDPOINT_LOCAL : GRAPHQL_ENDPOINT_PROD;
 export default GRAPHQL_ENDPOINT;


### PR DESCRIPTION
Client GQL endpoint address is client specific when in local.

Tested on android, untested on ios.

Long story short, Genymotion is running on Virtualbox, and the default network configuration is “Host-Only.” This method essentially emulates a physical network that is shared by your Genymotion VM (the emulator) and your host machine. The name of the network is vboxnet0, and if you run “ifconfig vboxnet0” (or “ipconfig vboxnet0” if running Windows) on your host machine, you should receive the IP address of your host on the vboxnet0 network. The default IP is most likely 192.168.56.1. This is the IP address to use when accessing your host machine from the Genymotion emulator. 