### PR TITLE
Make <ListItem> use marginTop instead of marginBottom

### DIFF
--- a/client/src/components/List/styles.js
+++ b/client/src/components/List/styles.js
@@ -15,8 +15,8 @@ const styles = extendAppStyleSheet({
     paddingRight: 16,
     marginLeft: 14,
     marginRight: 14,
-    marginTop: 0,
-    marginBottom: 6,
+    marginTop: 6,
+    marginBottom: 0,
   },
   textContainer: {
     flex: 1,


### PR DESCRIPTION
* There are currently no other users of this component.
* For the sole current use-case (#199) it is better to put the margin at the top rather than the bottom.
* If we need to be able to support using marginBottom again this can be added in as a flag/option.
* Another potential future improvement would be to detect when a cell is the last item and have it add marginBottom as well.