### PR TITLE
fix margins on list item holders

### DIFF
--- a/client/src/screens/events/Detail.js
+++ b/client/src/screens/events/Detail.js
@@ -235,9 +235,7 @@ class EventDetail extends Component {
     return (
       <View style={{ flex: 1 }}>
         <View style={{ flex: 1, ...StyleSheet.absoluteFillObject }}>
-          <View
-            style={{ top: 6 }}
-          >
+          <View>
             <Holder wide transparent>
               <ListItem
                 wide
@@ -283,7 +281,7 @@ class EventDetail extends Component {
           </MapView>
         </View>
         <View
-          style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}
+          style={{ position: 'absolute', bottom: 6, left: 0, right: 0 }}
         >
           <Holder wide transparent>
             <ListItem


### PR DESCRIPTION
Element margins got a little screwy on a previous merge. fixed.
<img width="549" alt="screenshot 2018-03-20 18 33 27" src="https://user-images.githubusercontent.com/5799222/37641277-397f2152-2c6d-11e8-8696-85415dde8771.png">
