### PR TITLE
Prevent travis from building PRs twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
 node_js: 6
 cache: yarn
+
+branches:
+  only:
+    - master
+
 env:
   - COMPONENT=client MODE=lint
   - COMPONENT=server MODE=lint


### PR DESCRIPTION
* It does this because it is building each new branch as well as each PR.
* Lets blacklist all branches except master.
* It should still build all new PRs.