### PR TITLE
strike through the text of days that are out of range

### DIFF
--- a/client/src/components/DateTime/styles.js
+++ b/client/src/components/DateTime/styles.js
@@ -46,6 +46,7 @@ const styles = StyleSheet.create({
   },
   dayLabel: {},
   dayLabelOutOfRange: {
+    textDecorationLine: 'line-through',
     color: Colors.bgOutOfRange,
   },
   dayLabelAvailable: {


### PR DESCRIPTION
Had issues with people not understanding which days were disabled. This (or something like it) might make it more obvious. 

<img width="540" alt="screenshot 2018-04-21 19 55 34" src="https://user-images.githubusercontent.com/5799222/39082901-0136f168-459e-11e8-8f95-74d054b64435.png">
