### PR TITLE
Make Monday start at 0 minutes 0 seconds

### DIFF
--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -5,6 +5,8 @@ const getMonday = () => {
   const now = new Date();
   const day = now.getDay() || 7;
   if (day !== 1) { now.setHours(-24 * (day - 1)); }
+  now.setMinutes(0);
+  now.setSeconds(0);
   return Math.floor(now.getTime() / 1000);
 };
 


### PR DESCRIPTION
Currently it preserves the current minutes and seconds. Fixed that.