### PR TITLE
make the start time match the written description

### DIFF
--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -207,7 +207,7 @@ export const SCHEDULES = [
   {
     name: 'Wagga Wagga OOA',
     details: 'Flood Rescue operators required for Wednesday deployment to Wagga Wagga. Leave Monday return Thursday',
-    startTime: MONDAY + (60 * 60 * 24 * 1),
+    startTime: MONDAY,
     endTime: MONDAY + (60 * 60 * 24 * 3),
     group: 'NSW SES',
     timeSegmentUsers: [


### PR DESCRIPTION
It said Monday but the time stamp said Tuesday.