### PR TITLE
Better tab navigation configuration

### DIFF
--- a/client/src/navigation/MainNavigator.js
+++ b/client/src/navigation/MainNavigator.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { TabNavigator } from 'react-navigation';
+import Icon from 'react-native-vector-icons/FontAwesome';
 import { compose } from 'react-apollo';
 import { connect } from 'react-redux';
-
 
 import { isLoggedIn } from '../selectors/auth';
 import HomeNavigator from './HomeNavigator';
@@ -31,11 +31,46 @@ const tabBarConfiguration = {
 // tabs in main screen
 const MainTabNavigator = TabNavigator(
   {
-    Home: { screen: HomeNavigator },
-    Groups: { screen: GroupsNavigator },
-    Availability: { screen: AvailabilityNavigator },
-    Events: { screen: EventsNavigator },
-    More: { screen: BurgerNavigator },
+    Home: {
+      screen: HomeNavigator,
+      navigationOptions: {
+        tabBarLabel: 'Home',
+        // eslint-disable-next-line react/prop-types
+        tabBarIcon: ({ tintColor }) => <Icon size={34} name="home" color={tintColor} />,
+      },
+    },
+    Groups: {
+      screen: GroupsNavigator,
+      navigationOptions: {
+        tabBarLabel: 'Groups',
+        // eslint-disable-next-line react/prop-types
+        tabBarIcon: ({ tintColor }) => <Icon size={24} name="group" color={tintColor} />,
+      },
+    },
+    Availability: {
+      screen: AvailabilityNavigator,
+      navigationOptions: {
+        tabBarLabel: 'Availability',
+        // eslint-disable-next-line react/prop-types
+        tabBarIcon: ({ tintColor }) => <Icon size={24} name="calendar" color={tintColor} />,
+      },
+    },
+    Events: {
+      screen: EventsNavigator,
+      navigationOptions: {
+        tabBarLabel: 'Events',
+        // eslint-disable-next-line react/prop-types
+        tabBarIcon: ({ tintColor }) => <Icon size={26} name="bullhorn" color={tintColor} />,
+      },
+    },
+    More: {
+      screen: BurgerNavigator,
+      navigationOptions: {
+        tabBarLabel: 'More',
+        // eslint-disable-next-line react/prop-types
+        tabBarIcon: ({ tintColor }) => <Icon size={28} name="bars" color={tintColor} />,
+      },
+    },
   },
   tabBarConfiguration,
 );

--- a/client/src/screens/availability/Detail.js
+++ b/client/src/screens/availability/Detail.js
@@ -35,8 +35,6 @@ const defaultSegmentState = [
 class Detail extends Component {
   static navigationOptions = ({ navigation }) => ({
     headerRight: <ButtonNavBar onPress={() => navigation.state.params.handleThis()} icon="info" />,
-    tabBarIcon: ({ tintColor }) => <Icon size={24} name="calendar" color={tintColor} />,
-    tabBarLabel: 'Availability',
     title: `${navigation.state.params.title}`,
   });
 

--- a/client/src/screens/availability/Requests.js
+++ b/client/src/screens/availability/Requests.js
@@ -3,7 +3,6 @@ import { View } from 'react-native';
 import SelectMultiple from 'react-native-select-multiple';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { graphql, compose } from 'react-apollo';
 
 import CURRENT_USER_QUERY from '../../graphql/current-user.query';
@@ -16,7 +15,6 @@ import { setSelectedRequests } from '../../state/availability.actions';
 class Requests extends Component {
   static navigationOptions = () => ({
     title: 'Requests',
-    tabBarIcon: ({ tintColor }) => <Icon size={24} name="calendar" color={tintColor} />,
   });
 
   onSelectionChange = (selectedRequests) => {

--- a/client/src/screens/availability/Root.js
+++ b/client/src/screens/availability/Root.js
@@ -3,7 +3,6 @@ import { FlatList, Text } from 'react-native';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { graphql, compose } from 'react-apollo';
-import Icon from 'react-native-vector-icons/FontAwesome';
 
 import CURRENT_USER_QUERY from '../../graphql/current-user.query';
 
@@ -16,8 +15,6 @@ import { Progress } from '../../components/Progress';
 class Index extends Component {
   static navigationOptions = () => ({
     title: 'Open Requests',
-    tabBarIcon: ({ tintColor }) => <Icon size={24} name="calendar" color={tintColor} />,
-    tabBarLabel: 'Availability',
   });
 
   onPressInfo = (item) => {

--- a/client/src/screens/burger/Profile.js
+++ b/client/src/screens/burger/Profile.js
@@ -6,7 +6,6 @@ import { graphql, compose } from 'react-apollo';
 import md5 from 'md5';
 import Prompt from 'react-native-prompt';
 
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { extendAppStyleSheet } from '../style-sheet';
 import CURRENT_USER_QUERY from '../../graphql/current-user.query';
 import UPDATE_USERPROFILE_MUTATION from '../../graphql/update-userprofile.mutation';
@@ -99,8 +98,6 @@ const styles = extendAppStyleSheet({
 class Profile extends Component {
   static navigationOptions = {
     title: 'My Profile',
-    tabBarLabel: 'More',
-    tabBarIcon: ({ tintColor }) => <Icon size={28} name="bars" color={tintColor} />,
   };
 
   state = {

--- a/client/src/screens/burger/Root.js
+++ b/client/src/screens/burger/Root.js
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { graphql, compose } from 'react-apollo';
 import DeviceInfo from 'react-native-device-info';
 import codePush from 'react-native-code-push';
-import Icon from 'react-native-vector-icons/FontAwesome';
 
 import { Button } from '../../components/Button';
 import { Center } from '../../components/Container';
@@ -38,7 +37,6 @@ const updateUserProfileMutation = graphql(UPDATE_USERPROFILE_MUTATION, {
 class Root extends Component {
   static navigationOptions = {
     title: 'More',
-    tabBarIcon: ({ tintColor }) => <Icon size={28} name="bars" color={tintColor} />,
   };
 
   updateLocation = () => {

--- a/client/src/screens/events/Detail.js
+++ b/client/src/screens/events/Detail.js
@@ -4,7 +4,6 @@ import React, { Component } from 'react';
 import { Text, View, Dimensions, StyleSheet } from 'react-native';
 import MapView, { Marker } from 'react-native-maps';
 import { graphql, compose } from 'react-apollo';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
 import moment from 'moment';
 import _ from 'lodash';
@@ -40,8 +39,6 @@ const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
 class Detail extends Component {
   static navigationOptions = {
     title: 'Event Detail',
-    tabBarLabel: 'Events',
-    tabBarIcon: ({ tintColor }) => <Icon size={26} name="bullhorn" color={tintColor} />,
   };
 
   static makeEventLocations(eventLocations) {

--- a/client/src/screens/events/EditResponse.js
+++ b/client/src/screens/events/EditResponse.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { ButtonNavBar } from '../../components/Button';
 import { SetResponse } from '../../components/Events';
 
@@ -21,9 +20,6 @@ const EditResponse = ({ navigation }) => {
 
 EditResponse.navigationOptions = () => ({
   title: 'Event Response',
-  tabBarLabel: 'Events',
-  // eslint-disable-next-line react/prop-types
-  tabBarIcon: ({ tintColor }) => <Icon size={26} name="bullhorn" color={tintColor} />,
   headerRight: <ButtonNavBar onPress={() => console.log('call soc')} icon="phone" />,
 });
 

--- a/client/src/screens/events/EventUsers.js
+++ b/client/src/screens/events/EventUsers.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import moment from 'moment';
 import { graphql, compose } from 'react-apollo';
 import { FlatList, Text, View, Alert } from 'react-native';
@@ -16,8 +15,6 @@ import { Segment } from '../../components/Segment';
 class EventUsers extends Component {
   static navigationOptions = {
     title: 'User Responses',
-    tabBarLabel: 'Events',
-    tabBarIcon: ({ tintColor }) => <Icon size={26} name="bullhorn" color={tintColor} />,
   };
 
   state = {

--- a/client/src/screens/events/Events.js
+++ b/client/src/screens/events/Events.js
@@ -7,7 +7,6 @@ import {
   View,
 } from 'react-native';
 import { graphql, compose } from 'react-apollo';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
 import { ListItem } from '../../components/List';
 import { Holder } from '../../components/Container';
@@ -52,12 +51,6 @@ Event.propTypes = {
 };
 
 class Events extends Component {
-  static navigationOptions = {
-    title: 'My Events',
-    tabBarLabel: 'Events',
-    tabBarIcon: ({ tintColor }) => <Icon size={26} name="bullhorn" color={tintColor} />,
-  };
-
   onRefresh = () => {
     this.props.refetch();
   }

--- a/client/src/screens/groups/GroupDetails.js
+++ b/client/src/screens/groups/GroupDetails.js
@@ -246,8 +246,6 @@ ScheduleDisplay.propTypes = {
 class GroupDetails extends Component {
   static navigationOptions = () => ({
     title: 'Group Details',
-    tabBarLabel: 'Groups',
-    tabBarIcon: ({ tintColor }) => <Icon size={24} name="group" color={tintColor} />,
   });
 
   onRefresh = () => {

--- a/client/src/screens/groups/NewGroup.js
+++ b/client/src/screens/groups/NewGroup.js
@@ -28,8 +28,6 @@ const goToNewGroup = () => NavigationActions.back();
 class NewGroup extends Component {
   static navigationOptions = () => ({
     title: 'New Group',
-    tabBarLabel: 'Groups',
-    tabBarIcon: ({ tintColor }) => <Icon size={24} name="group" color={tintColor} />,
   });
 
   state = {

--- a/client/src/screens/groups/Root.js
+++ b/client/src/screens/groups/Root.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { FlatList, Button, Text, View } from 'react-native';
 import { graphql, compose } from 'react-apollo';
-import Icon from 'react-native-vector-icons/FontAwesome';
 
 import { connect } from 'react-redux';
 
@@ -76,14 +75,12 @@ Group.propTypes = {
 class Root extends Component {
   static navigationOptions = ({ navigation }) => ({
     title: 'My Groups',
-    tabBarLabel: 'Groups',
-    tabBarIcon: ({ tintColor }) => <Icon size={24} name="group" color={tintColor} />,
-    headerRight:
-  <View style={{ flexDirection: 'row' }}>
-    <ButtonNavBar onPress={() => navigation.navigate('NewGroup')} icon="plus" />
-    <ButtonNavBar onPress={() => navigation.navigate('SearchGroup')} icon="search" />
-  </View>,
-
+    headerRight: (
+      <View style={{ flexDirection: 'row' }}>
+        <ButtonNavBar onPress={() => navigation.navigate('NewGroup')} icon="plus" />
+        <ButtonNavBar onPress={() => navigation.navigate('SearchGroup')} icon="search" />
+      </View>
+    ),
   });
 
   onRefresh = () => {

--- a/client/src/screens/groups/SearchGroup.js
+++ b/client/src/screens/groups/SearchGroup.js
@@ -3,8 +3,6 @@ import React, { Component } from 'react';
 import {
   FlatList,
 } from 'react-native';
-
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { connect } from 'react-redux';
 import _ from 'lodash';
 import { graphql, compose } from 'react-apollo';
@@ -71,10 +69,6 @@ Group.propTypes = {
 class SearchGroup extends Component {
   static navigationOptions = {
     title: 'Search for Groups',
-    tabBarLabel: 'Groups',
-    tabBarIcon: ({ tintColor }) => (
-      <Icon size={24} name="group" color={tintColor} />
-    ),
   };
 
   state = {

--- a/client/src/screens/home/Root.js
+++ b/client/src/screens/home/Root.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import Icon from 'react-native-vector-icons/FontAwesome';
 import { graphql, compose } from 'react-apollo';
 import { FlatList, Text, Button } from 'react-native';
 import { withNavigation } from 'react-navigation';
@@ -55,11 +54,6 @@ _HomeScheduleListItem.propTypes = {
 const HomeScheduleListItem = withNavigation(_HomeScheduleListItem);
 
 class Root extends Component {
-  static navigationOptions = {
-    title: 'Home',
-    tabBarIcon: ({ tintColor }) => <Icon size={34} name="home" color={tintColor} />,
-  };
-
   onRefresh = () => {
     this.props.refetch();
   };


### PR DESCRIPTION
* Preivously we would set the tab name, icon, title etc on each screen. This
  is silly and redundant and led to the tab icon changing as you pushed/popped
  views onto the navigators.
* Now we set the configuration in the tab navigator so that it applies to
  every screen.
* Bonus: we can now make generic screens and push them onto any stack
  represented by any tab without stuff getting weird.