### PR TITLE
Enable screen re-use and fixes

### DIFF
--- a/client/src/navigation/EventsNavigator.js
+++ b/client/src/navigation/EventsNavigator.js
@@ -1,17 +1,17 @@
 import { StackNavigator } from 'react-navigation';
 
-import { Events, Detail, EditResponse, EventUsers } from '../screens/events';
+import { Root, Detail, EditResponse, EventUsers } from '../screens/events';
 import NavOptions from '../config/NavOptions';
 
 const EventsNavigator = StackNavigator(
   {
-    Root: {
-      screen: Events,
+    EventRoot: {
+      screen: Root,
     },
-    Detail: {
+    EventDetail: {
       screen: Detail,
     },
-    EditResponse: {
+    EventEditResponse: {
       screen: EditResponse,
     },
     EventUsers: {

--- a/client/src/navigation/HomeNavigator.js
+++ b/client/src/navigation/HomeNavigator.js
@@ -2,19 +2,25 @@ import { StackNavigator } from 'react-navigation';
 
 import { Root } from '../screens/home';
 import NavOptions from '../config/NavOptions';
-import EventDetail from '../screens/events/Detail';
-import ScheduleDetail from '../screens/schedules/Detail';
+import { Detail as EventDetail, EditResponse, EventUsers } from '../screens/events';
+import { Detail as ScheduleDetail } from '../screens/schedules';
 
 const HomeNavigator = StackNavigator(
   {
     Root: {
       screen: Root,
     },
-    Event: {
+    SchedulesDetail: {
+      screen: ScheduleDetail,
+    },
+    EventDetail: {
       screen: EventDetail,
     },
-    Schedule: {
-      screen: ScheduleDetail,
+    EventEditResponse: {
+      screen: EditResponse,
+    },
+    EventUsers: {
+      screen: EventUsers,
     },
   },
   {

--- a/client/src/navigation/SchedulesNavigator.js
+++ b/client/src/navigation/SchedulesNavigator.js
@@ -1,18 +1,15 @@
 import { StackNavigator } from 'react-navigation';
 
-import { Root, Detail, Requests } from '../screens/schedules';
+import { Root, Detail } from '../screens/schedules';
 import NavOptions from '../config/NavOptions';
 
 const SchedulesNavigator = StackNavigator(
   {
-    Root: {
+    SchedulesRoot: {
       screen: Root,
     },
-    Detail: {
+    SchedulesDetail: {
       screen: Detail,
-    },
-    Requests: {
-      screen: Requests,
     },
   },
   {

--- a/client/src/screens/burger/Root.js
+++ b/client/src/screens/burger/Root.js
@@ -66,16 +66,9 @@ class Root extends Component {
     );
   }
 
-  showEventResponse = () => {
-    const { navigate } = this.props.navigation;
-    navigate('EventResponse', {
-      eventId: 1,
-    });
-  }
-
   showUserProfile = () => {
-    const { navigate } = this.props.navigation;
-    navigate('Profile');
+    const { navigation } = this.props;
+    navigation.push('Profile');
   }
 
   logout = () => {
@@ -140,9 +133,6 @@ class Root extends Component {
         <Button text="Force Update Location" onPress={this.updateLocation} />
         <Text />
         <Text />
-        <Button text="Test Event Response" onPress={this.showEventResponse} />
-        <Text />
-        <Text />
         <Button text="Check For Updates" onPress={this.checkForUpdate} />
         <Text />
         <Text />
@@ -162,7 +152,7 @@ Root.propTypes = {
   dispatch: PropTypes.func.isRequired,
   updateLocation: PropTypes.func,
   navigation: PropTypes.shape({
-    navigate: PropTypes.func.isRequired,
+    push: PropTypes.func.isRequired,
   }),
 };
 

--- a/client/src/screens/events/Detail.js
+++ b/client/src/screens/events/Detail.js
@@ -156,15 +156,15 @@ class Detail extends Component {
   geoWatch = null;
 
   editResponse = () => {
-    const { navigate } = this.props.navigation;
-    navigate('EditResponse', {
+    const { navigation } = this.props;
+    navigation.push('EventEditResponse', {
       eventId: this.props.event.id,
     });
   };
 
   eventUsers = () => {
-    const { navigate } = this.props.navigation;
-    navigate('EventUsers', {
+    const { navigation } = this.props;
+    navigation.push('EventUsers', {
       eventId: this.props.event.id,
     });
   };

--- a/client/src/screens/events/Root.js
+++ b/client/src/screens/events/Root.js
@@ -50,7 +50,11 @@ Event.propTypes = {
   }),
 };
 
-class Events extends Component {
+class Root extends Component {
+  static navigationOptions = {
+    title: 'My Events',
+  };
+
   onRefresh = () => {
     this.props.refetch();
   }
@@ -59,12 +63,7 @@ class Events extends Component {
 
   goToEvent = (event) => {
     const { navigate } = this.props.navigation;
-    navigate('Event', { id: event.id, title: event.name });
-  }
-
-  goToNewEvent = () => {
-    const { navigate } = this.props.navigation;
-    navigate('NewEvent');
+    navigate('EventDetail', { id: event.id, title: event.name });
   }
 
   renderItem = ({ item }) => <Event event={item} goToEvent={this.goToEvent} />;
@@ -105,7 +104,7 @@ class Events extends Component {
     );
   }
 }
-Events.propTypes = {
+Root.propTypes = {
   navigation: PropTypes.shape({
     navigate: PropTypes.func,
   }),
@@ -139,4 +138,4 @@ const mapStateToProps = ({ auth }) => ({
 export default compose(
   connect(mapStateToProps),
   userQuery,
-)(Events);
+)(Root);

--- a/client/src/screens/events/index.js
+++ b/client/src/screens/events/index.js
@@ -1,6 +1,6 @@
 import Detail from './Detail';
 import EditResponse from './EditResponse';
-import Events from './Events';
+import Root from './Root';
 import EventUsers from './EventUsers';
 
-export { Detail, EditResponse, Events, EventUsers };
+export { Detail, EditResponse, Root, EventUsers };

--- a/client/src/screens/home/Root.js
+++ b/client/src/screens/home/Root.js
@@ -16,7 +16,7 @@ import ScheduleListItem from '../../components/Schedules/ScheduleListItem';
 class _HomeEventListItem extends Component {
   onPress = () => {
     const { event, navigation } = this.props;
-    navigation.push('Event', { id: event.id });
+    navigation.push('EventDetail', { id: event.id });
   }
 
   render() {
@@ -36,7 +36,7 @@ const HomeEventListItem = withNavigation(_HomeEventListItem);
 class _HomeScheduleListItem extends Component {
   onPress = () => {
     const { schedule: { id, name }, navigation } = this.props;
-    navigation.push('Schedule', { id, title: name });
+    navigation.push('SchedulesDetail', { id, title: name });
   }
 
   render() {
@@ -54,6 +54,10 @@ _HomeScheduleListItem.propTypes = {
 const HomeScheduleListItem = withNavigation(_HomeScheduleListItem);
 
 class Root extends Component {
+  static navigationOptions = () => ({
+    title: 'Home',
+  });
+
   onRefresh = () => {
     this.props.refetch();
   };

--- a/client/src/screens/schedules/Root.js
+++ b/client/src/screens/schedules/Root.js
@@ -18,7 +18,7 @@ class Root extends Component {
   });
 
   onPressInfo = (item) => {
-    this.props.navigation.navigate('Detail', { id: item.id, title: item.name });
+    this.props.navigation.push('SchedulesDetail', { id: item.id, title: item.name });
   };
 
   onRefresh = () => {
@@ -80,7 +80,7 @@ class Root extends Component {
 Root.propTypes = {
   loading: PropTypes.bool,
   navigation: PropTypes.shape({
-    navigate: PropTypes.func,
+    push: PropTypes.func,
   }),
   networkStatus: PropTypes.number,
   refetch: PropTypes.func.isRequired,


### PR DESCRIPTION
* Screens are now re-used - you can navigate into events and schedules from
  home or from their respective tabs.
* Fixes for missing navigation controller titles.
* Remove stubs for creating events - we're not going to do this on the mobile
  app for now.
* Remove test event response button.