### PR TITLE
Set light-content status bar on iOS

### DIFF
--- a/client/src/navigation/RootNavigator.js
+++ b/client/src/navigation/RootNavigator.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { StatusBar, View } from 'react-native';
 import { SwitchNavigator } from 'react-navigation';
 
 import MainTabNavigator from './MainNavigator';
@@ -31,4 +33,13 @@ const RootNavigator = SwitchNavigator(
   },
 );
 
-export default RootNavigator;
+const RootNavigatorWithStatusBar = () => (
+  <View style={{ flex: 1 }}>
+    <StatusBar
+      barStyle="light-content"
+    />
+    <RootNavigator />
+  </View>
+);
+
+export default RootNavigatorWithStatusBar;


### PR DESCRIPTION
* Finally this works!
* We can override the color by adding additional `<StatusBar>` elements on
  other screens.