### PR TITLE
Introduce 'urgent' events and modal for response

### DIFF
--- a/client/src/components/Events/EventListItem.js
+++ b/client/src/components/Events/EventListItem.js
@@ -5,14 +5,15 @@ import { ListItem } from '../List';
 
 // this component is intended to be used to display basic information about an event in a
 // <FlatList> and go to event detail view when tapped
-const EventListItem = ({ event, onPress }) => (
+const EventListItem = ({ event, urgent, onPress }) => (
   <ListItem
     title={event.name}
     bold
     subtitle={event.details}
     subtitleEllipsis
-    icon="bullhorn"
+    icon={urgent ? 'exclamation-triangle' : 'bullhorn'}
     onPress={onPress}
+    urgent={urgent}
   />
 );
 
@@ -21,6 +22,7 @@ EventListItem.propTypes = {
   event: PropTypes.shape({
     name: PropTypes.string.isRequired,
   }),
+  urgent: PropTypes.bool,
 };
 
 export default EventListItem;

--- a/client/src/components/List/ListItem.js
+++ b/client/src/components/List/ListItem.js
@@ -15,11 +15,16 @@ const ListItem = ({
   detail,
   icon,
   onPress,
+  urgent,
 }) => {
   const containerStyles = [styles.container];
 
   if (wide) {
     containerStyles.push({ marginLeft: 0, marginRight: 0 });
+  }
+
+  if (urgent) {
+    containerStyles.push({ backgroundColor: '#FFDDDD' });
   }
 
   return (
@@ -58,6 +63,7 @@ ListItem.propTypes = {
   bold: PropTypes.bool,
   subtitleEllipsis: PropTypes.bool,
   wide: PropTypes.bool,
+  urgent: PropTypes.bool,
   subtitle: PropTypes.string,
   supertitle: PropTypes.string,
   detail: PropTypes.string,

--- a/client/src/navigation/AuthNavigator.js
+++ b/client/src/navigation/AuthNavigator.js
@@ -33,7 +33,7 @@ class AuthNavigator extends Component {
     const { auth } = this.props;
     if (isLoggedIn(auth)) {
       console.log('User is logged in - navigating to main');
-      this.props.navigation.navigate('Main');
+      this.props.navigation.navigate('ModalNavigator');
     }
   }
 

--- a/client/src/navigation/HomeNavigator.js
+++ b/client/src/navigation/HomeNavigator.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import PropTypes from 'prop-types';
 import { StackNavigator } from 'react-navigation';
 
 import { Root } from '../screens/home';
@@ -29,4 +31,12 @@ const HomeNavigator = StackNavigator(
   },
 );
 
-export default HomeNavigator;
+// this wrapper exists soley so we can pass the modalNavigation prop down to our child screens
+const HomeNavigatorWrapper = ({ screenProps }) => (
+  <HomeNavigator screenProps={screenProps} />
+);
+HomeNavigatorWrapper.propTypes = {
+  screenProps: PropTypes.shape({}),
+};
+
+export default HomeNavigatorWrapper;

--- a/client/src/navigation/MainNavigator.js
+++ b/client/src/navigation/MainNavigator.js
@@ -88,7 +88,7 @@ class MainNavigator extends Component {
 
   render() {
     return (
-      <MainTabNavigator />
+      <MainTabNavigator screenProps={{ modalNavigation: this.props.navigation }} />
     );
   }
 }

--- a/client/src/navigation/ModalNavigator.js
+++ b/client/src/navigation/ModalNavigator.js
@@ -1,0 +1,25 @@
+import { StackNavigator } from 'react-navigation';
+
+import MainNavigator from './MainNavigator';
+import { NewResponse as EventNewResponse } from '../screens/events';
+
+// this navigator hangs off the root SwitchNavigator and normally displays the
+// MainNavigator (TabNavigator). We use it to pop-up important fullscreen modals
+
+const ModalNavigator = StackNavigator(
+  {
+    Main: {
+      screen: MainNavigator,
+    },
+    EventNewResponse: {
+      screen: EventNewResponse,
+    },
+  },
+  {
+    headerMode: 'none',
+    mode: 'modal',
+    initialRouteName: 'Main',
+  },
+);
+
+export default ModalNavigator;

--- a/client/src/navigation/RootNavigator.js
+++ b/client/src/navigation/RootNavigator.js
@@ -2,9 +2,8 @@ import React from 'react';
 import { StatusBar, View } from 'react-native';
 import { SwitchNavigator } from 'react-navigation';
 
-import MainTabNavigator from './MainNavigator';
+import ModalNavigator from './ModalNavigator';
 import AuthStackNavigator from './AuthNavigator';
-import EditResponse from '../screens/events/EditResponse';
 import LoadingScreen from '../screens/auth/Loading';
 
 // the root stack shows no UI - it exists just so we can pop-up modals over 'Main' at the
@@ -16,14 +15,11 @@ const RootNavigator = SwitchNavigator(
     Loading: {
       screen: LoadingScreen,
     },
-    Main: {
-      screen: MainTabNavigator,
+    ModalNavigator: {
+      screen: ModalNavigator,
     },
     Auth: {
       screen: AuthStackNavigator,
-    },
-    Event: {
-      screen: EditResponse,
     },
   },
   {

--- a/client/src/screens/auth/Loading.js
+++ b/client/src/screens/auth/Loading.js
@@ -16,7 +16,7 @@ class Loading extends Component {
       this.props.navigation.navigate('Auth');
     } else {
       console.log('Going from loading screen to main because user is logged in');
-      this.props.navigation.navigate('Main');
+      this.props.navigation.navigate('ModalNavigator');
     }
   }
 

--- a/client/src/screens/events/Detail.js
+++ b/client/src/screens/events/Detail.js
@@ -349,7 +349,7 @@ Detail.propTypes = {
 
 const eventQuery = graphql(EVENT_QUERY, {
   skip: ownProps => !ownProps.auth || !ownProps.auth.token,
-  options: ({ navigation }) => ({ variables: { eventId: navigation.state.params.id } }),
+  options: ({ navigation }) => ({ variables: { eventId: navigation.state.params.eventId } }),
   props: ({ data: { loading, event, refetch } }) => ({
     loading,
     event,

--- a/client/src/screens/events/NewResponse.js
+++ b/client/src/screens/events/NewResponse.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { ButtonNavBar } from '../../components/Button';
+import { SetResponse } from '../../components/Events';
+
+const NewResponse = ({ navigation }) => {
+  const { params } = navigation.state;
+
+  const onClose = () => {
+    navigation.pop();
+  };
+
+  return (
+    <SetResponse
+      eventId={params.eventId}
+      onClose={onClose}
+    />
+  );
+};
+
+NewResponse.navigationOptions = () => ({
+  title: 'NEW EVENT',
+  headerRight: <ButtonNavBar onPress={() => console.log('call soc')} icon="exclamation-triangle" />,
+});
+
+NewResponse.propTypes = {
+  navigation: PropTypes.shape({
+    navigate: PropTypes.func,
+    goBack: PropTypes.func,
+  }),
+};
+
+export default NewResponse;

--- a/client/src/screens/events/index.js
+++ b/client/src/screens/events/index.js
@@ -2,5 +2,6 @@ import Detail from './Detail';
 import EditResponse from './EditResponse';
 import Root from './Root';
 import EventUsers from './EventUsers';
+import NewResponse from './NewResponse';
 
-export { Detail, EditResponse, Root, EventUsers };
+export { Detail, EditResponse, Root, EventUsers, NewResponse };

--- a/client/src/screens/home/Root.js
+++ b/client/src/screens/home/Root.js
@@ -16,7 +16,7 @@ import ScheduleListItem from '../../components/Schedules/ScheduleListItem';
 class _HomeEventListItem extends Component {
   onPress = () => {
     const { event, navigation } = this.props;
-    navigation.push('EventDetail', { id: event.id });
+    navigation.push('EventDetail', { eventId: event.id });
   }
 
   render() {
@@ -32,6 +32,26 @@ _HomeEventListItem.propTypes = {
   }),
 };
 const HomeEventListItem = withNavigation(_HomeEventListItem);
+
+class _HomeNewEventListItem extends Component {
+  onPress = () => {
+    const { event, modalNavigation } = this.props;
+    modalNavigation.push('EventNewResponse', { eventId: event.id });
+  }
+
+  render() {
+    return (
+      <EventListItem event={this.props.event} onPress={this.onPress} urgent />
+    );
+  }
+}
+_HomeNewEventListItem.propTypes = {
+  event: PropTypes.shape().isRequired,
+  modalNavigation: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }),
+};
+const HomeNewEventListItem = withNavigation(_HomeNewEventListItem);
 
 class _HomeScheduleListItem extends Component {
   onPress = () => {
@@ -66,6 +86,14 @@ class Root extends Component {
     if (item.type === 'event') {
       return <HomeEventListItem event={item.event} />;
     }
+    if (item.type === 'new-event') {
+      return (
+        <HomeNewEventListItem
+          event={item.event}
+          modalNavigation={this.props.screenProps.modalNavigation}
+        />
+      );
+    }
     if (item.type === 'schedule') {
       return <HomeScheduleListItem schedule={item.schedule} />;
     }
@@ -84,15 +112,28 @@ class Root extends Component {
       );
     }
     const items = [];
-    user.events.forEach((e) => {
+    const { events, schedules } = user;
+    const oneEvent = [events[Math.floor(Math.random() * events.length)]];
+
+    // here we create 2 entries for every event to show the difference between new events and
+    // ones the user has already responded to
+    events.forEach((e) => {
       items.push({
         type: 'event',
+        id: e.id,
+        event: e,
+        sortKey: 1,
+      });
+    });
+    oneEvent.forEach((e) => {
+      items.push({
+        type: 'new-event',
         id: e.id,
         event: e,
         sortKey: 0,
       });
     });
-    user.schedules.forEach((s) => {
+    schedules.forEach((s) => {
       items.push({
         type: 'schedule',
         id: s.id,
@@ -138,6 +179,11 @@ Root.propTypes = {
   loading: PropTypes.bool,
   networkStatus: PropTypes.number,
   refetch: PropTypes.func,
+  screenProps: PropTypes.shape({
+    modalNavigation: PropTypes.shape({
+      push: PropTypes.func,
+    }),
+  }),
   user: PropTypes.shape({
     id: PropTypes.number.isRequired,
     username: PropTypes.string.isRequired,


### PR DESCRIPTION
* We display a random event as urgent (just for testing)
* Urgent events will be events that meet certain criteria (ie rescue) that a
  user is able to respond to but has not yet recorded a response. Details tbc.
* Urgent events are shown on the home screen in a different colour and when
  tapped launch directly into the response flow.
* This repsonse flow is the same thing that will show in-app when you tap a
  push notification.
* Had to add a new `ModalNavigator` which sits between `RootNavigator`
  (`SwitchNavigator`) and `MainNavigator` (`TabNavigator`).
* The implementation is messy because I could not get `react-navigation` to
  navigate to a route defined in the `ModalNavigator` without passing it's
  navigation prop all the way down to the home root screen.