### PR TITLE
Suppress react warning relating to missing event response detail

### DIFF
--- a/client/src/screens/events/EventUsers.js
+++ b/client/src/screens/events/EventUsers.js
@@ -190,7 +190,7 @@ EventUsers.propTypes = {
           displayName: PropTypes.string.isRequired,
         }),
         status: PropTypes.string.isRequired,
-        detail: PropTypes.string.isRequired,
+        detail: PropTypes.string,
       }),
     ),
   }),


### PR DESCRIPTION
* The view works fine without it set and I think it's normal for it to
  sometimes be unset so lets remove the `isRequired` PropType.