### PR TITLE
Change "My Requests" to "My Availability"

### DIFF
--- a/client/src/screens/schedules/Root.js
+++ b/client/src/screens/schedules/Root.js
@@ -14,7 +14,7 @@ import { Progress } from '../../components/Progress';
 
 class Root extends Component {
   static navigationOptions = () => ({
-    title: 'Open Requests',
+    title: 'My Availability',
   });
 
   onPressInfo = (item) => {


### PR DESCRIPTION
* To match "My Events" and make it clear that the list includes ongoing
  availability - not just one-off requests.