### PR TITLE
Prefix `Root` components names for better debugging

### DIFF
--- a/client/src/screens/burger/Root.js
+++ b/client/src/screens/burger/Root.js
@@ -35,7 +35,7 @@ const updateUserProfileMutation = graphql(UPDATE_USERPROFILE_MUTATION, {
   }),
 });
 
-class Root extends Component {
+class BurgerRoot extends Component {
   static navigationOptions = {
     title: 'More',
   };
@@ -189,7 +189,7 @@ class Root extends Component {
   }
 }
 
-Root.propTypes = {
+BurgerRoot.propTypes = {
   dispatch: PropTypes.func.isRequired,
   updateLocation: PropTypes.func,
   navigation: PropTypes.shape({
@@ -215,4 +215,4 @@ export default compose(
   userQuery,
   updateUserProfileMutation,
   updateLocationMutation,
-)(Root);
+)(BurgerRoot);

--- a/client/src/screens/events/Root.js
+++ b/client/src/screens/events/Root.js
@@ -47,7 +47,7 @@ Event.propTypes = {
   }),
 };
 
-class Root extends Component {
+class EventsRoot extends Component {
   static navigationOptions = {
     title: 'My Events',
   };
@@ -101,7 +101,7 @@ class Root extends Component {
     );
   }
 }
-Root.propTypes = {
+EventsRoot.propTypes = {
   navigation: PropTypes.shape({
     navigate: PropTypes.func,
   }),
@@ -135,4 +135,4 @@ const mapStateToProps = ({ auth }) => ({
 export default compose(
   connect(mapStateToProps),
   userQuery,
-)(Root);
+)(EventsRoot);

--- a/client/src/screens/groups/Root.js
+++ b/client/src/screens/groups/Root.js
@@ -71,7 +71,7 @@ Group.propTypes = {
   }),
 };
 
-class Root extends Component {
+class GroupsRoot extends Component {
   static navigationOptions = ({ navigation }) => ({
     title: 'My Groups',
     headerRight: (
@@ -136,7 +136,7 @@ class Root extends Component {
     );
   }
 }
-Root.propTypes = {
+GroupsRoot.propTypes = {
   navigation: PropTypes.shape({
     navigate: PropTypes.func,
   }),
@@ -182,4 +182,4 @@ const mapStateToProps = ({ auth }) => ({
   auth,
 });
 
-export default compose(connect(mapStateToProps), userQuery)(Root);
+export default compose(connect(mapStateToProps), userQuery)(GroupsRoot);

--- a/client/src/screens/home/Root.js
+++ b/client/src/screens/home/Root.js
@@ -73,7 +73,7 @@ _HomeScheduleListItem.propTypes = {
 };
 const HomeScheduleListItem = withNavigation(_HomeScheduleListItem);
 
-class Root extends Component {
+class HomeRoot extends Component {
   static navigationOptions = () => ({
     title: 'Home',
   });
@@ -175,7 +175,7 @@ const userQuery = graphql(CURRENT_USER_QUERY, {
   }),
 });
 
-Root.propTypes = {
+HomeRoot.propTypes = {
   loading: PropTypes.bool,
   networkStatus: PropTypes.number,
   refetch: PropTypes.func,
@@ -203,4 +203,4 @@ const mapStateToProps = ({ auth }) => ({
   auth,
 });
 
-export default compose(connect(mapStateToProps), userQuery)(Root);
+export default compose(connect(mapStateToProps), userQuery)(HomeRoot);

--- a/client/src/screens/schedules/Root.js
+++ b/client/src/screens/schedules/Root.js
@@ -10,7 +10,7 @@ import { Center, Container } from '../../components/Container';
 import { ScheduleListItem } from '../../components/Schedules';
 import { Progress } from '../../components/Progress';
 
-class Root extends Component {
+class SchedulesRoot extends Component {
   static navigationOptions = () => ({
     title: 'My Availability',
   });
@@ -73,7 +73,7 @@ class Root extends Component {
   }
 }
 
-Root.propTypes = {
+SchedulesRoot.propTypes = {
   loading: PropTypes.bool,
   navigation: PropTypes.shape({
     push: PropTypes.func,
@@ -120,4 +120,4 @@ const mapStateToProps = ({ auth }) => ({
   auth,
 });
 
-export default compose(connect(mapStateToProps), userQuery)(Root);
+export default compose(connect(mapStateToProps), userQuery)(SchedulesRoot);


### PR DESCRIPTION
* Rename `Root` components so it is more obvious which is broken in stack
  traces.