### PR TITLE
Refactor capabilities into tags

### DIFF
--- a/client/src/graphql/all-groups.query.js
+++ b/client/src/graphql/all-groups.query.js
@@ -14,12 +14,13 @@ export default gql`
             icon
             id
             tags {
-              name
               id
+              name
+              type
             }
             users {
-             username
              id
+             username
             }
             schedules {
               id

--- a/client/src/graphql/create-group.mutation.js
+++ b/client/src/graphql/create-group.mutation.js
@@ -9,12 +9,13 @@ export default gql`
       name
       icon
       tags {
-         name
          id
+         name
+         type
        }
        users {
-         username
          id
+         username
        }
     }
   }

--- a/client/src/graphql/current-user.query.js
+++ b/client/src/graphql/current-user.query.js
@@ -13,7 +13,9 @@ export default gql`
         name
         icon
         tags {
+          id
           name
+          type
         }
       }
       events {

--- a/client/src/graphql/groups-users.query.js
+++ b/client/src/graphql/groups-users.query.js
@@ -7,15 +7,16 @@ export default gql`
       id
       organisation {
         groups {
-          name
           id
+          name
           users {
-            username
             id
+            username
           }
           tags {
-            name
             id
+            name
+            type
           }
         }
       }

--- a/client/src/graphql/join-group.mutation.js
+++ b/client/src/graphql/join-group.mutation.js
@@ -6,12 +6,13 @@ export default gql`
       id
       name
       tags {
-        name
         id
+        name
+        type
       }
       users {
-        username
         id
+        username
       }
       events {
         id

--- a/client/src/graphql/organisation-tags.query.js
+++ b/client/src/graphql/organisation-tags.query.js
@@ -2,14 +2,15 @@ import gql from 'graphql-tag';
 
 // get the orgs tags
 export default gql`
-  query tag($filter: String){
+  query tag($nameFilter: String,$typeFilter: String){
     user {
       id
       organisation {
         id
-        tags(filter: $filter) {
+        tags(nameFilter: $nameFilter,typeFilter: $typeFilter) {
             id
             name
+            type
         }
       }
     }

--- a/client/src/graphql/search-group.query.js
+++ b/client/src/graphql/search-group.query.js
@@ -14,13 +14,14 @@ export default gql`
             icon
             id
             tags {
-              name
               id
+              name
+              type
             }
             users {
+             id
              username
              displayName
-             id
             }
             schedules {
               id

--- a/client/src/screens/groups/NewGroup.js
+++ b/client/src/screens/groups/NewGroup.js
@@ -98,7 +98,7 @@ searchTagOnPress = (text) => {
 }
 
 applyTagSearchFilter = () => {
-  this.props.refetch({ filter: this.state.filterString });
+  this.props.refetch({ nameFilter: this.state.filterString });
 }
 
   create = () => {
@@ -208,6 +208,7 @@ NewGroup.propTypes = {
         PropTypes.shape({
           id: PropTypes.number.isRequired,
           name: PropTypes.string.isRequired,
+          type: PropTypes.string.isRequired,
         }),
       ),
     }),
@@ -225,7 +226,8 @@ NewGroup.propTypes = {
 const tagsQuery = graphql(ORGANISATION_TAGS, {
   options: () => ({
     variables: {
-      filter: '',
+      nameFilter: '',
+      typeFilter: 'orgStructure',
     },
   }),
   props: ({ data: { loading, networkStatus, refetch, user } }) => ({

--- a/server/src/__tests__/creators.js
+++ b/server/src/__tests__/creators.js
@@ -60,50 +60,23 @@ describe('create event', () => {
 
 describe('create tag', () => {
   const name = 'test';
-  const group = { id: 34556 };
-  const user = { id: 548746 };
-  const organisation = { id: 1248 };
+  const type = 'group';
+  const organisation = { id: 1 };
 
-  it('rejects due to missing user', async () => {
-    await expect(creators.tag({})).rejects.toThrow();
-  });
-
-  it('rejects due to missing group', async () => {
-    await expect(creators.tag({ user })).rejects.toThrow();
+  it('rejects due to missing type', async () => {
+    await expect(creators.tag({ name })).rejects.toThrow();
   });
 
   it('rejects due to missing organisation', async () => {
-    await expect(creators.tag({ user, group })).rejects.toThrow();
+    await expect(creators.tag({ name, type })).rejects.toThrow();
   });
 
   it('returns a tag', async () => {
-    const result = await creators.tag({ name, user, group, organisation });
+    const result = await creators.tag({ name, type, organisation });
 
     expect(result.id).toBeDefined();
     expect(result.name).toBe(name);
     expect(result.organisationId).toBe(organisation.id);
-  });
-});
-
-describe('create capability', () => {
-  const name = 'test';
-  const user = { id: 548746 };
-  const organisation = { id: 1248 };
-
-  it('rejects due to missing organisation', async () => {
-    await expect(creators.capability({})).rejects.toThrow();
-  });
-
-  it('rejects due to missing user', async () => {
-    await expect(creators.capability({ organisation })).rejects.toThrow();
-  });
-
-  it('returns a capability', async () => {
-    const result = await creators.capability({ name, organisation, user });
-
-    // this returns the user rather than the capability which isn't ideal
-    // but lets test for it for now
-    expect(result.id).toBe(user.id);
   });
 });
 

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -108,9 +108,6 @@ export const getHandlers = ({ models, creators: Creators }) => {
       tags(user) {
         return user.getTags();
       },
-      capabilities(user) {
-        return user.getCapabilities();
-      },
       signup(args, ctx) {
         const { deviceUuid, email, username, password } = args.user;
 
@@ -419,13 +416,14 @@ export const getHandlers = ({ models, creators: Creators }) => {
         return org.getUsers();
       },
       tags(org, args) {
-        if (args.filter) {
-          return org.getTags({ where: { name: { [Op.like]: `%${args.filter}%` } }, order: [['id', 'ASC']] });
+        const where = {};
+        if (args.nameFilter) {
+          where.name = { [Op.like]: `%${args.nameFilter}%` };
         }
-        return org.getTags();
-      },
-      capabilities(org) {
-        return org.getCapabilities();
+        if (args.typeFilter) {
+          where.type = { [Op.like]: `%${args.typeFilter}%` };
+        }
+        return org.getTags({ where, order: [['id', 'ASC']] });
       },
     },
 

--- a/server/src/models-mock.js
+++ b/server/src/models-mock.js
@@ -25,12 +25,9 @@ export const defineModels = () => {
     version: 1,
   });
 
-  const CapabilityModel = db.define('capability', {
-    name: 'test',
-  });
-
   const TagModel = db.define('tag', {
     name: 'test',
+    type: 'group',
   });
 
   const DeviceModel = db.define('device', {
@@ -132,10 +129,6 @@ export const defineModels = () => {
   GroupModel.belongsToMany(TagModel, { through: 'group_tag' });
   TagModel.belongsToMany(GroupModel, { through: 'group_tag' });
 
-  // users belong to capability tags
-  UserModel.belongsToMany(CapabilityModel, { through: 'user_capability' });
-  CapabilityModel.belongsToMany(UserModel, { through: 'user_capability' });
-
   // events are created for a single group
   EventModel.belongsTo(GroupModel);
   GroupModel.hasMany(EventModel);
@@ -164,15 +157,10 @@ export const defineModels = () => {
   TagModel.belongsTo(OrganisationModel);
   OrganisationModel.hasMany(TagModel);
 
-  // tags belong to one organisation for now
-  CapabilityModel.belongsTo(OrganisationModel);
-  OrganisationModel.hasMany(CapabilityModel);
-
   return {
     Organisation: db.models.organisation,
     Group: db.models.group,
     User: db.models.user,
-    Capability: db.models.capability,
     Tag: db.models.tag,
     Device: db.models.device,
     Event: db.models.event,

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -20,12 +20,9 @@ export const defineModels = (db) => {
     version: { type: Sequelize.INTEGER }, // version the password
   });
 
-  const CapabilityModel = db.define('capability', {
-    name: { type: Sequelize.STRING },
-  });
-
   const TagModel = db.define('tag', {
     name: { type: Sequelize.STRING },
+    type: { type: Sequelize.STRING },
   });
 
   const DeviceModel = db.define('device', {
@@ -130,10 +127,6 @@ export const defineModels = (db) => {
   GroupModel.belongsToMany(TagModel, { through: 'group_tag' });
   TagModel.belongsToMany(GroupModel, { through: 'group_tag' });
 
-  // users belong to capability tags
-  UserModel.belongsToMany(CapabilityModel, { through: 'user_capability' });
-  CapabilityModel.belongsToMany(UserModel, { through: 'user_capability' });
-
   // events are created for a single group
   EventModel.belongsTo(GroupModel);
   GroupModel.hasMany(EventModel);
@@ -167,15 +160,10 @@ export const defineModels = (db) => {
   TagModel.belongsTo(OrganisationModel);
   OrganisationModel.hasMany(TagModel);
 
-  // tags belong to one organisation for now
-  CapabilityModel.belongsTo(OrganisationModel);
-  OrganisationModel.hasMany(CapabilityModel);
-
   return {
     Organisation: db.models.organisation,
     Group: db.models.group,
     User: db.models.user,
-    Capability: db.models.capability,
     Tag: db.models.tag,
     Device: db.models.device,
     Event: db.models.event,

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -17,7 +17,8 @@ export const Schema = [
 
   input TagInput {
     id: Int!
-    name: String
+    name: String,
+    type: String,
   }
 
   input CreateGroupInput {
@@ -115,7 +116,7 @@ export const Schema = [
     name: String!
     users: [User]!
     groups(id: Int,filter: String): [Group]!
-    tags(filter: String): [Tag]!
+    tags(nameFilter: String,typeFilter: String): [Tag]!
     capabilities: [Capability]!
   }
 
@@ -148,6 +149,7 @@ export const Schema = [
   type Tag {
     id: Int!
     name: String!
+    type: String!
   }
 
   type Capability {

--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -22,12 +22,10 @@ export const DEFAULT_GROUP = 'NSW SES';
 
 export const ORG_NAME = 'NSW SES';
 
-
 const makeTags = (rawTags) => {
   const results = [];
-  Object.entries(rawTags).forEach((entry) => {
-    const [type, value] = entry;
-    value.forEach((tag) => {
+  Object.keys(rawTags).forEach((type) => {
+    rawTags[type].forEach((tag) => {
       results.push({ name: tag, type });
     });
   });

--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -36,6 +36,7 @@ const makeTags = (rawTags) => {
 
 export const TAGS = makeTags({
   orgStructure: [
+    'NSW',
     'SWR',
     'ISR',
     'SSR',

--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -22,26 +22,52 @@ export const DEFAULT_GROUP = 'NSW SES';
 
 export const ORG_NAME = 'NSW SES';
 
-export const CAPABILITIES = [
-  'Road Crash Rescue',
-  'Vertical Rescue',
-  'Flood Rescue',
-  'Chainsaw',
-];
 
-export const TAGS = [
-  'NSW',
-  'SWR',
-  'ISR',
-  'SSR',
-  'KMA',
-  'PAR',
-  'HLS',
-  'WOL',
-  'AUB',
-  'HAW',
-  'HOL',
-];
+const makeTags = (rawTags) => {
+  const results = [];
+  Object.entries(rawTags).forEach((entry) => {
+    const [type, value] = entry;
+    value.forEach((tag) => {
+      results.push({ name: tag, type });
+    });
+  });
+  return results;
+};
+
+export const TAGS = makeTags({
+  orgStructure: [
+    'SWR',
+    'ISR',
+    'SSR',
+    'KMA',
+    'PAR',
+    'HLS',
+    'HOL',
+    'AUB',
+    'HAW',
+    'HOL',
+  ],
+  capability: [
+    'Storm and Water Damage - Ground',
+    'Storm and Water Damage - Heights',
+    'Flood Rescue Operator Level 1',
+    'Flood Rescue Operator Level 2',
+    'Flood Rescue Boat Operator',
+    'Flood Rescue Operator Level 3',
+    'General Land Rescue Operator',
+    'Road Crash Rescue Operator',
+    'Community First Responder Registration',
+    'Vertical Rescue Operator',
+    'Chainsaw L1 (Cross Cut)',
+    'Chainsaw L2 (Intermediate Felling)',
+    'Land Search',
+    'SES IM Incident Controller',
+    'SES IM Planning Officer',
+    'SES IM Public Information Officer',
+    'SES IM Operations Officer',
+    'SES IM Logistics Officer',
+  ],
+});
 
 export const USERS = [
   {
@@ -50,6 +76,11 @@ export const USERS = [
     password: 'test',
     displayName: 'Paddy Platypus',
     email: 'test@example.com',
+    tags: [
+      'Road Crash Rescue Operator',
+      'Chainsaw L1 (Cross Cut)',
+      'Land Search',
+    ],
   },
   {
     id: 11,
@@ -57,6 +88,10 @@ export const USERS = [
     password: 'test',
     displayName: 'Alex Alpha',
     email: 'kiama1@example.com',
+    tags: [
+      'Vertical Rescue Operator',
+      'SES IM Incident Controller',
+    ],
   },
   {
     id: 12,
@@ -64,6 +99,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Bob Bravo',
     email: 'kiama2@example.com',
+    tags: ['SES IM Logistics Officer'],
   },
   {
     id: 13,
@@ -71,6 +107,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Caroline Charlie',
     email: 'kiama3@example.com',
+    tags: ['SES IM Public Information Officer'],
   },
   {
     id: 14,
@@ -78,6 +115,7 @@ export const USERS = [
     password: 'test',
     displayName: 'David Delta',
     email: 'kiama4@example.com',
+    tags: [],
   },
   {
     id: 15,
@@ -85,6 +123,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Erin Echo',
     email: 'kiama4@example.com',
+    tags: [],
   },
   {
     id: 16,
@@ -92,6 +131,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Fabio Foxtrot',
     email: 'kiama6@example.com',
+    tags: [],
   },
   {
     id: 17,
@@ -99,6 +139,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Greg Golf',
     email: 'kiama7@example.com',
+    tags: [],
   },
   {
     id: 18,
@@ -106,6 +147,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Heather Hotel',
     email: 'kiama8@example.com',
+    tags: [],
   },
   {
     id: 21,
@@ -113,6 +155,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Tim Dykes',
     email: 'paramatta1@example.com',
+    tags: [],
   },
   {
     id: 22,
@@ -120,6 +163,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Ian India',
     email: 'parramatta2@example.com',
+    tags: [],
   },
   {
     id: 23,
@@ -127,6 +171,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Jane Juliet',
     email: 'parramatta3@example.com',
+    tags: [],
   },
   {
     id: 24,
@@ -134,6 +179,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Katt Kilo',
     email: 'parramatta4@example.com',
+    tags: [],
   },
   {
     id: 25,
@@ -141,6 +187,7 @@ export const USERS = [
     password: 'test',
     displayName: 'Luke Lima',
     email: 'parramatta5@example.com',
+    tags: [],
   },
 ];
 

--- a/server/tests/current-user.test.js
+++ b/server/tests/current-user.test.js
@@ -36,9 +36,6 @@ describe('GraphQL query - Current user', () => {
             tags {
               id
             }
-            capabilities {
-              id
-            }
           }
         }
       }
@@ -60,10 +57,6 @@ describe('GraphQL query - Current user', () => {
     it('Returns tags', () => response.then((res) => {
       expect(res.data.user.organisation.tags.length).toBeGreaterThan(0);
       expect(res.data.user.organisation.tags[0]).toHaveProperty('id');
-    }));
-    it('Returns capabilities', () => response.then((res) => {
-      expect(res.data.user.organisation.capabilities.length).toBeGreaterThan(0);
-      expect(res.data.user.organisation.capabilities[0]).toHaveProperty('id');
     }));
   });
 
@@ -246,21 +239,6 @@ describe('GraphQL query - Current user', () => {
         user {
           id
           tags {
-            id
-          }
-        }
-      }
-    `);
-
-    itReturnsSuccess(response);
-  });
-
-  describe('Get capabilities', () => {
-    const response = query(`
-      {
-        user {
-          id
-          capabilities {
             id
           }
         }


### PR DESCRIPTION
Migration of the user capabilities data into Tag data.

Not trying to be better than the current capabilities or tags, just moving the code over. So I haven't added user tag handlers or screens yet.

The overall Apollo cache will be a bit happier now as we were missing ID on some data type so the cache would have been confused.

**Server**

Update to DB model
- remove capabilities
- add type to tags as ENUM (prob not a good idea long term)

Update of GQL schema
- type added
- filter to allow queries to filter on type

Update of test data & generator

Update to integration tests
- fixed from previous model to pre this PR model (was still expecting user and group to be passed)
- updated to support tag type

logic.js updated
- removed capabilities  
- query filter on tag name or type

**Client**

Update to Apollo GQL queries
- added id to anything that was missing it
- add tag type and tag filters
- reorder id to be first in all queries

Update to screens
- type added to props
- default types on queries added