### PR TITLE
Travis Jest tweaks

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "react-native start",
-    "test": "TZ=UTC jest",
-    "test-and-coverage": "TZ=UTC jest && codecov -F unittests",
+    "test": "TZ=UTC jest --maxWorkers=4",
+    "test-and-coverage": "TZ=UTC jest --maxWorkers=4 && codecov -F unittests",
     "push-ios": "code-push release-react availability-poc-ios ios",
     "push-android": "code-push release-react availability-poc-android android",
     "run-ios": "react-native run-ios",

--- a/server/package.json
+++ b/server/package.json
@@ -12,9 +12,9 @@
     "build": "bash scripts/build.sh",
     "serve": "node dist/main.js",
     "lint": "eslint src tests",
-    "test-integration": "jest tests/ && codecov -F integration",
-    "test-unit": "jest --testPathIgnorePatterns '^<rootDir>/(tests|dist)/' && codecov -F unittests",
-    "test": "jest --testPathIgnorePatterns '^<rootDir>/(tests|dist)/'"
+    "test-integration": "jest tests/ --maxWorkers=4&& codecov -F integration",
+    "test-unit": "jest --maxWorkers=4 --testPathIgnorePatterns '^<rootDir>/(tests|dist)/' && codecov -F unittests",
+    "test": "jest --maxWorkers=4 --testPathIgnorePatterns '^<rootDir>/(tests|dist)/'"
   },
   "jest": {
     "coverageDirectory": "./coverage/",


### PR DESCRIPTION
Should fix the stupidly slow jest snapshot test times we are currently getting on Travis but limiting the number of workers that Travis spawns (currently unlimited) by locking it down to 4