### PR TITLE
no bugsnag if in DEV

### DIFF
--- a/client/src/app.js
+++ b/client/src/app.js
@@ -18,7 +18,7 @@ console.log(`Using GraphQL endpoint: ${GRAPHQL_ENDPOINT}`);
 const networkInterface = createNetworkInterface({ uri: GRAPHQL_ENDPOINT });
 let store;
 
-export const bugsnag = BugSnagClient.typeof === undefined ? new BugSnagClient() : undefined;
+export const bugsnag = !__DEV__ ? new BugSnagClient() : undefined;
 
 // middleware for requests
 networkInterface.use([


### PR DESCRIPTION
use the __DEV__ flag to disable bugsnag.


I replaced the old check which I cannot understand how it was working as the logic was wrong as that always returns undefined because it has no typeof. I think I got lucky that the library protected its self from missing linked code.