### PR TITLE
Skip gathering/printing test coverage for default `yarn test`

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "start": "react-native start",
-    "test": "TZ=UTC jest --maxWorkers=4",
-    "test-and-coverage": "TZ=UTC jest --maxWorkers=4 && codecov -F unittests",
+    "test": "TZ=UTC jest",
+    "test-and-coverage": "TZ=UTC jest --maxWorkers=4 --coverage && codecov -F unittests",
     "push-ios": "code-push release-react availability-poc-ios ios",
     "push-android": "code-push release-react availability-poc-android android",
     "run-ios": "react-native run-ios",
@@ -83,7 +83,6 @@
     "collectCoverageFrom": [
       "src/**/*.js",
       "*.js"
-    ],
-    "collectCoverage": true
+    ]
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -12,13 +12,12 @@
     "build": "bash scripts/build.sh",
     "serve": "node dist/main.js",
     "lint": "eslint src tests",
-    "test-integration": "jest tests/ --maxWorkers=4&& codecov -F integration",
-    "test-unit": "jest --maxWorkers=4 --testPathIgnorePatterns '^<rootDir>/(tests|dist)/' && codecov -F unittests",
-    "test": "jest --maxWorkers=4 --testPathIgnorePatterns '^<rootDir>/(tests|dist)/'"
+    "test-integration": "jest tests/ --maxWorkers=4 --coverage && codecov -F integration",
+    "test-unit": "jest --maxWorkers=4 --testPathIgnorePatterns '^<rootDir>/(tests|dist)/' --coverage && codecov -F unittests",
+    "test": "jest --testPathIgnorePatterns '^<rootDir>/(tests|dist)/'"
   },
   "jest": {
     "coverageDirectory": "./coverage/",
-    "collectCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.js"
     ]


### PR DESCRIPTION
* Workflow efficiency improvement since most of the time we aren't looking.
* Use `yarn test --coverage` if you want to see it.
* Traivs still gathers it for both server and client.
* Also remove worker cap for `yarn test` in both server and client but keep for
  Travis.