### PR TITLE
Save device name to the server

### DIFF
--- a/client/src/components/push/PushHandler.js
+++ b/client/src/components/push/PushHandler.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import DeviceInfo from 'react-native-device-info';
 
 import { isLoggedIn } from '../../selectors/auth';
 
@@ -19,6 +20,7 @@ class PushHandler extends React.Component {
     this.updatePromise = null;
     this.didRegister = false;
   }
+
   componentDidMount() {
     this.onMountOrUpdate();
   }
@@ -77,8 +79,9 @@ class PushHandler extends React.Component {
     log('Server has: ', device.pushToken);
     if (jsonTokens !== device.pushToken) {
       log('Sending tokens to the server: ', jsonTokens);
-      this.updatePromise = this.props.updateToken({
+      this.updatePromise = this.props.updateDevice({
         token: jsonTokens,
+        name: DeviceInfo.getDeviceName(),
       }).then(() => {
         log('Token update was successful');
       }).catch((err) => {
@@ -94,7 +97,7 @@ class PushHandler extends React.Component {
 PushHandler.propTypes = {
   // eslint-disable-next-line react/forbid-prop-types
   pushManager: PropTypes.object,
-  updateToken: PropTypes.func,
+  updateDevice: PropTypes.func,
   auth: PropTypes.shape().isRequired,
   device: PropTypes.shape({
     pushToken: PropTypes.string,

--- a/client/src/graphql/index.js
+++ b/client/src/graphql/index.js
@@ -15,7 +15,7 @@ import SEARCH_GROUP_QUERY from './search-group.query';
 import SET_EVENT_RESPONSE_MUTATION from './set-event-response.mutation';
 import SIGNUP_MUTATION from './signup.mutation';
 import UPDATE_LOCATION_MUTATION from './update-location.mutation';
-import UPDATE_TOKEN_MUTATION from './update-token.mutation';
+import UPDATE_DEVICE_MUTATION from './update-device.mutation';
 import UPDATE_USERPROFILE_MUTATION from './update-userprofile.mutation';
 
 import {
@@ -42,7 +42,7 @@ export {
   SET_EVENT_RESPONSE_MUTATION,
   SIGNUP_MUTATION,
   UPDATE_LOCATION_MUTATION,
-  UPDATE_TOKEN_MUTATION,
+  UPDATE_DEVICE_MUTATION,
   UPDATE_USERPROFILE_MUTATION,
   CREATE_TIME_SEGMENT_MUTATION,
   REMOVE_TIME_SEGMENT_MUTATION,

--- a/client/src/graphql/update-device.mutation.js
+++ b/client/src/graphql/update-device.mutation.js
@@ -1,0 +1,7 @@
+import gql from 'graphql-tag';
+
+export default gql`
+  mutation updateDevice($device: DeviceUpdateInput!) {
+    updateDevice(device: $device)
+  }
+`;

--- a/client/src/graphql/update-token.mutation.js
+++ b/client/src/graphql/update-token.mutation.js
@@ -1,7 +1,0 @@
-import gql from 'graphql-tag';
-
-export default gql`
-  mutation updateToken($token: TokenUpdateInput!) {
-    updateToken(token: $token)
-  }
-`;

--- a/client/src/navigation/MainNavigator.js
+++ b/client/src/navigation/MainNavigator.js
@@ -15,7 +15,7 @@ import EventsNavigator from './EventsNavigator';
 import BurgerNavigator from './BurgerNavigator';
 import PushHandler from '../components/push/PushHandler';
 
-import UPDATE_TOKEN_MUTATION from '../graphql/update-token.mutation';
+import UPDATE_DEVICE_MUTATION from '../graphql/update-device.mutation';
 import CURRENT_DEVICE_QUERY from '../graphql/current-device.query';
 
 const fontSize = Platform.OS === 'ios' ? 10 : 8;
@@ -95,12 +95,12 @@ class MainNavigator extends Component {
   }
 
   render() {
-    const { device, auth, updateToken } = this.props;
+    const { device, auth, updateDevice } = this.props;
 
     return (
       <View style={{ flex: 1 }}>
         <PushHandler
-          updateToken={updateToken}
+          updateDevice={updateDevice}
           pushManager={pushManager}
           auth={auth}
           device={device}
@@ -119,7 +119,7 @@ MainNavigator.propTypes = {
     pushToken: PropTypes.string,
   }),
   auth: PropTypes.shape().isRequired,
-  updateToken: PropTypes.func.isRequired,
+  updateDevice: PropTypes.func.isRequired,
 };
 
 const deviceQuery = graphql(CURRENT_DEVICE_QUERY, {
@@ -132,11 +132,11 @@ const deviceQuery = graphql(CURRENT_DEVICE_QUERY, {
   }),
 });
 
-const updateTokenMutation = graphql(UPDATE_TOKEN_MUTATION, {
+const updateDeviceMutation = graphql(UPDATE_DEVICE_MUTATION, {
   props: ({ mutate }) => ({
-    updateToken: token =>
+    updateDevice: device =>
       mutate({
-        variables: { token },
+        variables: { device },
       }),
   }),
 });
@@ -147,7 +147,7 @@ const mapStateToProps = ({ auth, device }) => ({
 });
 
 export default compose(
-  updateTokenMutation,
+  updateDeviceMutation,
   connect(mapStateToProps),
   deviceQuery,
 )(MainNavigator);

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -49,10 +49,16 @@ export const getHandlers = ({ models, creators: Creators }) => {
           });
         });
       },
-      updateToken(_, args, ctx) {
-        return getAuthenticatedDevice(ctx).then(device => device.update({
-          pushToken: args.token.token,
-        }));
+      updateDevice(_, args, ctx) {
+        const { name, token } = args.device;
+        const params = {};
+        if (name) {
+          params.name = name;
+        }
+        if (token) {
+          params.pushToken = token;
+        }
+        return getAuthenticatedDevice(ctx).then(device => device.update(params));
       },
       updateLocation(_, args, ctx) {
         return getAuthenticatedDevice(ctx).then((device) => {

--- a/server/src/models-mock.js
+++ b/server/src/models-mock.js
@@ -32,6 +32,7 @@ export const defineModels = () => {
 
   const DeviceModel = db.define('device', {
     uuid: '1234abc',
+    name: 'test-device',
     pushToken: 'testpushtoken',
     locationLat: -34.4267554,
     locationLon: 150.8880039,

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -27,6 +27,7 @@ export const defineModels = (db) => {
 
   const DeviceModel = db.define('device', {
     uuid: { type: Sequelize.STRING },
+    name: { type: Sequelize.STRING },
     pushToken: { type: Sequelize.STRING },
     locationLat: { type: Sequelize.STRING },
     locationLon: { type: Sequelize.STRING },

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -155,8 +155,8 @@ export const getResolvers = (handlers) => {
       updateUserProfile(_, args, ctx) {
         return userHandler.updateUserProfile(_, args, ctx);
       },
-      updateToken(_, args, ctx) {
-        return deviceHandler.updateToken(_, args, ctx);
+      updateDevice(_, args, ctx) {
+        return deviceHandler.updateDevice(_, args, ctx);
       },
       updateLocation(_, args, ctx) {
         return deviceHandler.updateLocation(_, args, ctx);

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -13,7 +13,8 @@ export const Schema = [
     locationLon: String!
   }
 
-  input TokenUpdateInput {
+  input DeviceUpdateInput {
+    name: String
     token: String!
   }
 
@@ -163,6 +164,7 @@ export const Schema = [
 
   type Device {
     id: Int!
+    name: String  # device name from device info
     uuid: String!
     pushToken: String
     locationLat: String
@@ -263,7 +265,7 @@ export const Schema = [
     login(user: LoginInput!): User
     signup(user: SignupInput!): User
     updateLocation(location: LocationUpdateInput!): Boolean
-    updateToken(token: TokenUpdateInput!): Boolean
+    updateDevice(device: DeviceUpdateInput!): Boolean
     setEventResponse(response: SetEventResponseInput!): EventResponse
   }
 


### PR DESCRIPTION
* Allows us to more easily track which device is doing what during testing
* Device name comes from `react-native-device-info`.
* Synced to server whenever we update the push token.
* Re-work the `<PushHandler>` tests to use Jest Mock Functions.