### PR TITLE
Apollo endpoint server address

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,10 +1,5 @@
-import { Platform } from 'react-native';
-
-
 export const GRAPHQL_ENDPOINT_PROD = 'https://ses-availability-api.herokuapp.com/graphql';
-export const GRAPHQL_ENDPOINT_LOCAL = Platform.OS === 'ios' ?
-  'http://localhost:8080/graphql' :
-  'http://192.168.56.1:8080/graphql';
+export const GRAPHQL_ENDPOINT_LOCAL = 'http://localhost:8080/graphql';
 
 export const GRAPHQL_ENDPOINT = __DEV__ ? GRAPHQL_ENDPOINT_LOCAL : GRAPHQL_ENDPOINT_PROD;
 export default GRAPHQL_ENDPOINT;


### PR DESCRIPTION
Android users should use `adb reverse tcp:8080 tcp:8080` to get ports from phone to computer, we dont need to use private addresses.