### PR TITLE
Always display version number

### DIFF
--- a/client/src/screens/auth/Home.js
+++ b/client/src/screens/auth/Home.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import DeviceInfo from 'react-native-device-info';
 
 import { getCodePushHash } from '../../utils';
+import DeviceInfo from '../../selectors/deviceInfo';
 import Home from './components/Home';
 
 class HomeScreen extends Component {
@@ -21,11 +21,9 @@ class HomeScreen extends Component {
         codePushHash: value,
       });
     });
-    if (DeviceInfo.typeof !== undefined) {
-      this.setState({
-        version: DeviceInfo.getReadableVersion(),
-      });
-    }
+    this.setState({
+      version: DeviceInfo.getVersionString(),
+    });
   }
 
   goToSignIn = () => {

--- a/client/src/screens/burger/Params.js
+++ b/client/src/screens/burger/Params.js
@@ -6,7 +6,7 @@ import codePush from 'react-native-code-push';
 
 import { Container } from '../../components/Container';
 import ParamsList from './components/ParamsList';
-import { gatherDeviceInfo } from '../../selectors/deviceInfo';
+import DeviceInfo from '../../selectors/deviceInfo';
 
 import CURRENT_USER_QUERY from '../../graphql/current-user.query';
 import CURRENT_DEVICE_QUERY from '../../graphql/current-device.query';
@@ -24,7 +24,7 @@ class ParamsScreen extends Component {
   };
 
   componentDidMount() {
-    gatherDeviceInfo().then((result) => {
+    DeviceInfo.gatherDeviceInfo().then((result) => {
       const deviceInfo = stringify(result);
       this.setState({ deviceInfo });
     });

--- a/client/src/selectors/deviceInfo.js
+++ b/client/src/selectors/deviceInfo.js
@@ -51,5 +51,10 @@ const gatherDeviceInfo = async () => {
   return info;
 };
 
-// eslint-disable-next-line import/prefer-default-export
-export { gatherDeviceInfo };
+const getVersionString = () => {
+  const version = DeviceInfo.getVersion();
+  const build = DeviceInfo.getBuildNumber();
+  return `${version} (${build})`;
+};
+
+export default { gatherDeviceInfo, getVersionString };


### PR DESCRIPTION
* This might break on shells with no device info but we will address this in future.
* The existing device info check didn't work.
* Display version as `<version> (<build>)` ie `0.1 (6)`
* Move function to `deviceInfo` selector.
* Rewrite callers.