### PR TITLE
Remove isRequired for refetch prop on Schedules root

### DIFF
--- a/client/src/screens/schedules/Root.js
+++ b/client/src/screens/schedules/Root.js
@@ -79,7 +79,7 @@ SchedulesRoot.propTypes = {
     push: PropTypes.func,
   }),
   networkStatus: PropTypes.number,
-  refetch: PropTypes.func.isRequired,
+  refetch: PropTypes.func,
   user: PropTypes.shape({
     id: PropTypes.number.isRequired,
     username: PropTypes.string.isRequired,


### PR DESCRIPTION
Fixs prop error when not logged in. This is the only place we have this func as required, all the other roots its not. this throws errors when the user logs out.

@sjmcculloch this is your baby so Ill let you make a call on this. I don't know the ramifications of my change im just addressing the symptoms 