### PR TITLE
Update to the SES hook to create jobs from a HTTP POST.

### DIFF
--- a/scripts/hook.py
+++ b/scripts/hook.py
@@ -1,5 +1,7 @@
 import requests
 import json
+import pprint
+pp = pprint.PrettyPrinter(indent=4)
 
 data = {
     "Id": 28795,
@@ -8,7 +10,7 @@ data = {
     "FloodAssistanceJob": False,
     "ReferringAgency": None,
     "ReferringAgencyReference": None,
-    "SituationOnScene": None,
+    "SituationOnScene": "Things about stuff",
     "EvacuationRequired": False,
     "PeopleInundated": 0,
     "PeopleExtricated": 0,
@@ -134,4 +136,5 @@ data = {
 
 headers = {'content-type': 'application/json'}
 
-requests.post("http://localhost:8080/hook", data=json.dumps(data), headers=headers)
+r = requests.post("http://localhost:8080/hook", data=json.dumps(data), headers=headers)
+pp.pprint(r.text)

--- a/server/src/callback.js
+++ b/server/src/callback.js
@@ -1,25 +1,52 @@
+import { Op } from 'sequelize';
+
+
 const SESCallback = {
   creator: undefined,
+  models: undefined,
   eventCallback(req, res) {
     const job = {
-      name: req.body.JobType.Name,
+      name: `${req.body.JobType.Name} - ${req.body.Address.PrettyAddress}`,
       identifier: req.body.Identifier,
       description: req.body.JobType.Description,
+      SituationOnScene: req.body.SituationOnScene,
+      tags: req.body.Tags,
     };
+    // look for a group with the LHQ name in it, or use group id:1
+    this.models.Group.findOne({ where: { name: { [Op.like]: `%${req.body.EntityAssignedTo.Code}%` } } }).then((group) => {
+      Promise.resolve(this.creator.event({
+        name: job.name,
+        details: `${job.SituationOnScene} [${job.tags.map(g => `#${g.Name}`).join(', ')}]`,
+        identifier: job.identifier,
+        permalink: `https://beacon.com/job/${job.identifier}`,
+        group: group || { id: 1 },
+      }).then((event) => {
+        Promise.all(
+          [
+            this.creator.eventLocation({
+              name: 'hlq',
+              detail: req.body.EntityAssignedTo.Code,
+              icon: 'scene',
+              locationLatitude: req.body.EntityAssignedTo.Latitude,
+              locationLongitude: req.body.EntityAssignedTo.Longitude,
+              primaryLocation: true,
+              event,
+            }),
+            this.creator.eventLocation({
+              name: 'scene',
+              detail: req.body.Address.PrettyAddress,
+              icon: 'scene',
+              locationLatitude: req.body.Address.Latitude,
+              locationLongitude: req.body.Address.Longitude,
+              primaryLocation: false,
+              event,
+            }),
+          ],
+        );
+      }),
+      );
+    });
 
-    Promise.resolve(this.creator.location({
-      name: 'scene',
-      detail: req.body.Address.PrettyAddress,
-      locationLatitude: req.body.Address.Latitude,
-      locationLongitude: req.body.Address.Longitude,
-    }).then(eventLocation => this.creator.event({
-      name: job.name,
-      description: job.description,
-      identifier: job.identifier,
-      permalink: `https://beacon.com/job/${job.identifier}`,
-      location: eventLocation,
-      group: { id: 1 },
-    })));
 
     // get the base handler to add the event
     // send notifications (probably belongs in the other code)
@@ -27,10 +54,11 @@ const SESCallback = {
   },
 };
 
-function getCallback(type, creator) {
+function getCallback(type, creator, models) {
   if (type === 'ses-hook') {
     SESCallback.creator = creator;
-    console.log(SESCallback.creator);
+    SESCallback.models = models;
+
     return SESCallback.eventCallback.bind(SESCallback);
   }
   return null;

--- a/server/src/callback.js
+++ b/server/src/callback.js
@@ -13,57 +13,44 @@ const SESCallback = {
       tags: req.body.Tags,
     };
     // look for a group with the LHQ name in it, or use group id:1
-    this.models.Group.findOne({ where: { name: { [Op.like]: `%${req.body.EntityAssignedTo.Code}%` } } }).then((group) => {
-      Promise.resolve(this.creator.event({
-        name: job.name,
-        details: `${job.SituationOnScene} [${job.tags.map(g => `#${g.Name}`).join(', ')}]`,
-        identifier: job.identifier,
-        permalink: `https://beacon.com/job/${job.identifier}`,
-        group: group || { id: 1 },
-      }).then(event => Promise.all(
-        [
-          this.creator.eventLocation({
-            name: 'hlq',
-            detail: req.body.EntityAssignedTo.Code,
-            icon: 'scene',
-            locationLatitude: req.body.EntityAssignedTo.Latitude,
-            locationLongitude: req.body.EntityAssignedTo.Longitude,
-            primaryLocation: true,
-            event,
-          }),
-          this.creator.eventLocation({
-            name: 'scene',
-            detail: req.body.Address.PrettyAddress,
-            icon: 'scene',
-            locationLatitude: req.body.Address.Latitude,
-            locationLongitude: req.body.Address.Longitude,
-            primaryLocation: false,
-            event,
-          }),
-        ],
-      ).then(() => {
-        // we are done?
-        const result = {
+    this.models.Group.findOne({ where: { name: { [Op.like]: `%${req.body.EntityAssignedTo.Code}%` } } }).then(group => Promise.resolve(this.creator.event({
+      name: job.name,
+      details: `${job.SituationOnScene} [${job.tags.map(g => `#${g.Name}`).join(', ')}]`,
+      identifier: job.identifier,
+      permalink: `https://beacon.com/job/${job.identifier}`,
+      group: group || { id: 1 },
+    }).then(event => Promise.all(
+      [
+        this.creator.eventLocation({
+          name: 'lhq',
+          detail: req.body.EntityAssignedTo.Code,
+          icon: 'lhq',
+          locationLatitude: req.body.EntityAssignedTo.Latitude,
+          locationLongitude: req.body.EntityAssignedTo.Longitude,
+          primaryLocation: true,
           event,
-        };
-        res.send(JSON.stringify(result));
-      }).catch((err) => {
-        const result = {
-          status: err,
-        };
-        res.send(JSON.stringify(result));
-      })).catch((err) => {
-        const result = {
-          status: err,
-        };
-        res.send(JSON.stringify(result));
-      }),
-      ).catch((err) => {
-        const result = {
-          status: err,
-        };
-        res.send(JSON.stringify(result));
-      });
+        }),
+        this.creator.eventLocation({
+          name: 'scene',
+          detail: req.body.Address.PrettyAddress,
+          icon: 'scene',
+          locationLatitude: req.body.Address.Latitude,
+          locationLongitude: req.body.Address.Longitude,
+          primaryLocation: false,
+          event,
+        }),
+      ],
+    )),
+    )).then(() => {
+      const result = {
+        status: 'OK',
+      };
+      res.send(JSON.stringify(result));
+    }).catch(() => {
+      const result = {
+        status: 'FAIL',
+      };
+      res.send(JSON.stringify(result));
     });
 
 

--- a/server/src/callback.js
+++ b/server/src/callback.js
@@ -20,37 +20,55 @@ const SESCallback = {
         identifier: job.identifier,
         permalink: `https://beacon.com/job/${job.identifier}`,
         group: group || { id: 1 },
-      }).then((event) => {
-        Promise.all(
-          [
-            this.creator.eventLocation({
-              name: 'hlq',
-              detail: req.body.EntityAssignedTo.Code,
-              icon: 'scene',
-              locationLatitude: req.body.EntityAssignedTo.Latitude,
-              locationLongitude: req.body.EntityAssignedTo.Longitude,
-              primaryLocation: true,
-              event,
-            }),
-            this.creator.eventLocation({
-              name: 'scene',
-              detail: req.body.Address.PrettyAddress,
-              icon: 'scene',
-              locationLatitude: req.body.Address.Latitude,
-              locationLongitude: req.body.Address.Longitude,
-              primaryLocation: false,
-              event,
-            }),
-          ],
-        );
+      }).then(event => Promise.all(
+        [
+          this.creator.eventLocation({
+            name: 'hlq',
+            detail: req.body.EntityAssignedTo.Code,
+            icon: 'scene',
+            locationLatitude: req.body.EntityAssignedTo.Latitude,
+            locationLongitude: req.body.EntityAssignedTo.Longitude,
+            primaryLocation: true,
+            event,
+          }),
+          this.creator.eventLocation({
+            name: 'scene',
+            detail: req.body.Address.PrettyAddress,
+            icon: 'scene',
+            locationLatitude: req.body.Address.Latitude,
+            locationLongitude: req.body.Address.Longitude,
+            primaryLocation: false,
+            event,
+          }),
+        ],
+      ).then(() => {
+        // we are done?
+        const result = {
+          event,
+        };
+        res.send(JSON.stringify(result));
+      }).catch((err) => {
+        const result = {
+          status: err,
+        };
+        res.send(JSON.stringify(result));
+      })).catch((err) => {
+        const result = {
+          status: err,
+        };
+        res.send(JSON.stringify(result));
       }),
-      );
+      ).catch((err) => {
+        const result = {
+          status: err,
+        };
+        res.send(JSON.stringify(result));
+      });
     });
 
 
     // get the base handler to add the event
     // send notifications (probably belongs in the other code)
-    res.send('OK');
   },
 };
 

--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -29,7 +29,7 @@ export const getCreators = (models) => {
       });
     },
 
-    event: ({ name, details, sourceIdentifier, permalink, group, location }) => {
+    event: ({ name, details, sourceIdentifier, permalink, group }) => {
       if (!group || !group.id) {
         return Promise.reject(Error('Must pass group'));
       }
@@ -38,19 +38,11 @@ export const getCreators = (models) => {
         details,
         sourceIdentifier,
         permalink,
-        location,
         groupId: group.id,
         startTime: (new Date()).getTime() / 1000,
         endTime: DISTANT_FUTURE, // no end time
       });
     },
-
-    location: ({ name, detail, locationLatitude, locationLongitude }) => EventLocation.create({
-      name,
-      detail,
-      locationLatitude,
-      locationLongitude,
-    }),
 
     tag: ({ name, type, organisation }) => {
       if (!organisation || !organisation.id) {
@@ -166,7 +158,15 @@ export const getCreators = (models) => {
         eventlocationId: (destination ? destination.id : null),
       });
     },
-    eventLocation: ({ name, detail, icon, locationLatitude, locationLongitude, event }) => {
+    eventLocation: ({
+      name,
+      detail,
+      icon,
+      locationLatitude,
+      locationLongitude,
+      primaryLocation,
+      event,
+    }) => {
       if (!event || !event.id) {
         return Promise.reject(Error('Must pass event'));
       }
@@ -177,6 +177,11 @@ export const getCreators = (models) => {
         locationLatitude,
         locationLongitude,
         eventId: event.id,
+      }).then((location) => {
+        if (primaryLocation) {
+          event.update({ primaryLocationId: location.id });
+        }
+        return location;
       });
     },
     message: ({ text, user, groupId, eventId, scheduleId }) => {

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -31,6 +31,7 @@ export const getHandlers = ({ models, creators: Creators, push }) => {
     Schedule,
     Event,
     TimeSegment,
+    EventLocation,
   } = models;
 
   const handlers = {
@@ -334,6 +335,12 @@ export const getHandlers = ({ models, creators: Creators, push }) => {
       },
       eventLocations(event) {
         return event.getEventlocations();
+      },
+      primaryLocation(event) {
+        // to avoid a cyclic table associations we are calling 'constraints: false'
+        // so we have to do a traditional SELECT to get the item back
+        // because there is no forign key
+        return EventLocation.findById(event.primaryLocationId);
       },
       createEvent(_, args, ctx) {
         const { name, details, sourceIdentifier, permalink, eventLocations, groupId } = args.event;

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -80,7 +80,7 @@ app.use(
     endpointURL: GRAPHQL_PATH,
   }),
 );
-console.log(models);
+
 app.use('/hook', bodyParser.json(), getCallback('ses-hook', creators, models));
 
 const graphQLServer = createServer(app);

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -80,8 +80,8 @@ app.use(
     endpointURL: GRAPHQL_PATH,
   }),
 );
-
-app.use('/hook', bodyParser.json(), getCallback('ses-hook', creators));
+console.log(models);
+app.use('/hook', bodyParser.json(), getCallback('ses-hook', creators, models));
 
 const graphQLServer = createServer(app);
 

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -145,13 +145,15 @@ export const defineModels = (db) => {
   // event responses belong to a combination of user/event
   EventResponseModel.belongsTo(EventModel);
   EventModel.hasMany(EventResponseModel);
-  EventModel.hasOne(EventLocationModel, { as: 'primaryLocation' });
   EventResponseModel.belongsTo(UserModel);
   UserModel.hasMany(EventResponseModel);
 
   // event marker locations belong to an event
   EventLocationModel.belongsTo(EventModel);
   EventModel.hasMany(EventLocationModel);
+  // 'constraints: false ' to avoid Cyclic dependency
+  // https://github.com/sequelize/sequelize/issues/1717
+  EventModel.belongsTo(EventLocationModel, { as: 'primaryLocation', constraints: false });
 
   // event marker locations belong to a eventResponse
   EventResponseModel.belongsTo(EventLocationModel);

--- a/server/src/resolvers.js
+++ b/server/src/resolvers.js
@@ -95,6 +95,9 @@ export const getResolvers = (handlers) => {
       eventLocations(event, args, ctx) {
         return eventHandler.eventLocations(event, args, ctx);
       },
+      primaryLocation(event, args, ctx) {
+        return eventHandler.primaryLocation(event, args, ctx);
+      },
       messages(group, args, ctx) {
         return eventHandler.messages(group, args, ctx);
       },

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -209,6 +209,7 @@ export const Schema = [
     responses: [EventResponse]!
     messages: [Message]
     eventLocations: [EventLocation]
+    primaryLocation: EventLocation
     startTime: Int!
     endTime: Int!
   }

--- a/server/src/test-data/load.js
+++ b/server/src/test-data/load.js
@@ -113,12 +113,15 @@ const createEventLocation = (Creators, event, location) => {
     locationLatitude,
     locationLongitude,
   } = location;
+  // lets assume LHQ is the default for now
+  const primaryLocation = (name.toLowerCase() === 'lhq');
   return Creators.eventLocation({
     name,
     detail,
     icon,
     locationLatitude,
     locationLongitude,
+    primaryLocation,
     event,
   });
 };


### PR DESCRIPTION
Updated the hook code to create jobs.
Update the model and schema to support primaryLocation.
Update the location creator to handle primaryLocation flag.


We might want to change the model to work backwards to how i did it. I hold the ID of the primary group but we don't currently reuse locations so we could just have a boolean in the location that makes it the default.

I had to do some fuckery with the second one-to-one in the DB with the foreign key that I don't fully understand. Something @sdunster might want to check.

Made a bunch of assumptions in this code and more than happy for people to challenge them.

- Im looking for a group that has the LHQ name that the job is assigned to in it, if nothing found it will use group 1.
- Im making LHQ the primary location for the job.
- Im making the details of the job the situation on scene plus a join of the tags array.



if you run the python script in /scripts/hook.py you should get the following event created.

```
{
          "name": "Storm - 12 GILMORE STREET, WEST WOLLONGONG",
          "details": "Things about stuff [#Flooded]",
          "primaryLocation": {
            "name": "hlq",
            "detail": "WOL"
          },
          "eventLocations": [
            {
              "name": "hlq",
              "detail": "WOL",
              "locationLatitude": -34.40247,
              "locationLongitude": 150.89495
            },
            {
              "name": "scene",
              "detail": "12 GILMORE STREET, WEST WOLLONGONG",
              "locationLatitude": -34.41949,
              "locationLongitude": 150.87497
            }
          ]
        }
      ]
    }
```