### PR TITLE
Event - User location fix to store location time in seconds no milliseconds

### DIFF
--- a/client/src/screens/events/Detail.js
+++ b/client/src/screens/events/Detail.js
@@ -266,7 +266,7 @@ class Detail extends Component {
         id: props.event.id,
         locationLatitude: latitude,
         locationLongitude: longitude,
-        locationTime: position.timestamp,
+        locationTime: Math.floor(position.timestamp / 1000), // seconds not milliseconds
       })
       .then(() => {
         console.log('location change sent');


### PR DESCRIPTION
Math to convert milliseconds since epoch to seconds since epoch.

Fixed #424 