### PR TITLE
Super Awesome Push Token Improvements

### DIFF
--- a/client/src/components/push/__tests__/PushHandler.js
+++ b/client/src/components/push/__tests__/PushHandler.js
@@ -8,11 +8,15 @@ const testDeviceName = 'test device';
 DeviceInfo.getDeviceName = jest.fn(() => testDeviceName);
 
 class MockPushManager {
+  hasAllTokens = false
+  tokens = {}
   // eslint-disable-next-line class-methods-use-this
   async register({ onTokenUpdate }) {
     this.registerPromise = new Promise((resolve) => {
       setTimeout(() => {
-        onTokenUpdate({ test: 'TEST_TOKEN' });
+        this.hasAllTokens = true;
+        this.tokens.test = 'TEST_TOKEN';
+        onTokenUpdate();
         resolve();
       }, 500);
     });

--- a/client/src/graphql/update-device.mutation.js
+++ b/client/src/graphql/update-device.mutation.js
@@ -2,6 +2,10 @@ import gql from 'graphql-tag';
 
 export default gql`
   mutation updateDevice($device: DeviceUpdateInput!) {
-    updateDevice(device: $device)
+    updateDevice(device: $device) {
+      id
+      uuid
+      pushToken
+    }
   }
 `;

--- a/client/src/navigation/MainNavigator.js
+++ b/client/src/navigation/MainNavigator.js
@@ -143,6 +143,11 @@ const updateDeviceMutation = graphql(UPDATE_DEVICE_MUTATION, {
     updateDevice: device =>
       mutate({
         variables: { device },
+        update: (store) => {
+          // read the current device object, write in the new token, save it out
+          const data = store.readQuery({ query: CURRENT_DEVICE_QUERY });
+          store.writeQuery({ query: CURRENT_DEVICE_QUERY, data });
+        },
       }),
   }),
 });

--- a/client/src/push/dummy.js
+++ b/client/src/push/dummy.js
@@ -1,0 +1,41 @@
+class DummyClient {
+  constructor(pushManager) {
+    this.pushManager = pushManager;
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  init() {
+    return Promise.resolve();
+  }
+
+  // return a promise that resolves when we have called updateToken on the push manager at least
+  // once
+  register() {
+    const promise = new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+
+    // simulate an async token update
+    setTimeout(() => {
+      this.pushManager.updateToken('dummy', 'DUMMY_TOKEN2');
+    }, 1000 * 20);
+
+    return promise.then(() => {
+      this.pushManager.updateToken('dummy', 'DUMMY_TOKEN1');
+    });
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  async deregister() {
+    // not really needed for dummy implementation
+  }
+}
+
+const init = (pushManager) => {
+  const promise = new Promise((resolve) => {
+    setTimeout(resolve, 1000);
+  });
+  return promise.then(() => Promise.resolve(new DummyClient(pushManager)));
+};
+
+export default init;

--- a/client/src/push/index.js
+++ b/client/src/push/index.js
@@ -1,5 +1,6 @@
 import PushManager from './manager';
+import dummy from './dummy';
 import apns from './apns';
 import fcm from './fcm';
 
-export { PushManager, apns, fcm };
+export { PushManager, dummy, apns, fcm };

--- a/client/src/push/manager.js
+++ b/client/src/push/manager.js
@@ -22,13 +22,20 @@ class PushManager {
 
     const apns = await initAPNS(this);
     if (apns !== null) {
+      console.log('APNS loaded');
       this.services.apns = apns;
+    } else {
+      console.log('APNS not loaded');
     }
 
     const fcm = await initFCM(this);
     if (fcm !== null) {
+      console.log('FCM loaded');
       this.services.fcm = fcm;
+    } else {
+      console.log('FCM not loaded');
     }
+
 
     _.forEach(this.services, (s) => {
       promises.push(s.init());
@@ -82,9 +89,9 @@ class PushManager {
     });
 
     await Promise.all(promises);
-
-    this.onTokenUpdate(this.tokens);
     this.hasAllTokens = true;
+    console.log('hasAllTokens');
+    this.onTokenUpdate(this.tokens);
   }
 
   // call this to prevent further notifications from being received/processed.

--- a/client/src/push/manager.js
+++ b/client/src/push/manager.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import initDummy from './dummy';
 import initAPNS from './apns';
 import initFCM from './fcm';
 
@@ -19,6 +20,8 @@ class PushManager {
   // happen before register is called
   async init() {
     const promises = [];
+
+    this.services.dummy = await initDummy(this);
 
     const apns = await initAPNS(this);
     if (apns !== null) {

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -299,7 +299,7 @@ export const Schema = [
     login(user: LoginInput!): User
     signup(user: SignupInput!): User
     updateLocation(location: LocationUpdateInput!): Boolean
-    updateDevice(device: DeviceUpdateInput!): Boolean
+    updateDevice(device: DeviceUpdateInput!): Device
     setEventResponse(response: SetEventResponseInput!): EventResponse
     sendTestPush(vars: SendTestPushInput): Boolean  # send a push notification to the requesting device
   }


### PR DESCRIPTION
Updated server and client GQL to return a device when updating device (will make the cache happier)

Changed the way FCM was registering. I think returning a promise of the registration was bad, using the await should be better.

Added some more verbose log messages for tokens.

Added a direct cache update to the UpdateDevice mutation. I was seeing that calling this mutation caused PushManager to run again before the previous mutation had finished, which still had the old token and caused a massive loop. Directly writing the new value into the device prop seems to have fixed this.

Added some control to the push component to stop it from updating its self due it technically updating a prop from within its self it was causing an update etc. Wont update if the new prop device token is the same as the one it just sent to the server.