### PR TITLE
Unsub from FCM as per the documentation

### DIFF
--- a/client/src/push/fcm.js
+++ b/client/src/push/fcm.js
@@ -93,7 +93,7 @@ class FCMClient {
   async deregister() {
     // here we tell firebase we don't care about further updates to the push token
     if (this.refreshTokenListener) {
-      this.refreshTokenListener.remove();
+      this.refreshTokenListener();
     }
   }
 }

--- a/client/src/push/fcm.js
+++ b/client/src/push/fcm.js
@@ -93,7 +93,7 @@ class FCMClient {
   async deregister() {
     // here we tell firebase we don't care about further updates to the push token
     if (this.refreshTokenListener) {
-      this.refreshTokenListener();
+      this.refreshTokenListener = null;
     }
   }
 }


### PR DESCRIPTION
Fixes "undefined is not a function (evaluating 'this.refreshTokenListener.remove()')" as reported by Bugsnag.

Honestly FCM seems to have no way of turning it off or removing your token so we cant really unregister.