### PR TITLE
Server - Check server health before running tests

### DIFF
--- a/scripts/travis-yarn.sh
+++ b/scripts/travis-yarn.sh
@@ -7,10 +7,6 @@ then
 
   echo "Starting server..."
   yarn run serve &
-
-  # wait 10 seconds for the server to boot and load the test data
-  # TODO: run the server in-process
-  sleep 10
 fi
 
 echo "Running $CMD on $COMPONENT..."

--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "build": "bash scripts/build.sh",
     "serve": "node dist/main.js",
     "lint": "eslint src tests",
-    "test-integration": "jest tests/ --maxWorkers=4 --coverage && codecov -F integration",
+    "test-integration": "bash scripts/health-check.sh && jest tests/ --maxWorkers=4 --coverage && codecov -F integration",
     "test-unit": "jest --maxWorkers=4 --testPathIgnorePatterns '^<rootDir>/(tests|dist)/' --coverage && codecov -F unittests",
     "test": "jest --testPathIgnorePatterns '^<rootDir>/(tests|dist)/'",
     "apns-test": "babel-node scripts/apns.js"

--- a/server/scripts/health-check.sh
+++ b/server/scripts/health-check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# This script is made to run check server health and exit with a status of 0
+# if the server is up, otherwise exit with a status of 1 after trying 10 times.
+
+hasRun=false
+for i in {1..10}
+do
+  echo "Getting server health via /healthcheck... (Attempt "$i" of 10)"
+  serverHealth=$(curl --write-out %{http_code} --silent --output /dev/null http://localhost:8080/healthcheck)
+  echo "Server healthcheck returned..."$serverHealth
+
+  if [ $serverHealth -eq 200 ]
+  then
+    echo "Server returned status 200"
+    hasRun=true
+    break
+  fi
+  if [ $hasRun == false ]
+  then
+    echo "Server didnt return status 200"
+    echo "Waiting for 5 seconds..."
+   sleep 5
+ fi
+done
+
+if [ $hasRun == false ]
+then
+  echo "Giving up"
+ exit 1
+else
+  echo "Success! existing."
+  exit 0
+fi


### PR DESCRIPTION
Runs a bash script that waits for the health script to return 200 before running tests.

Wrote as a bash script to that if the tests are changed or expanded we can wrap them in the same check.

Closes #80 