### PR TITLE
Server - test data event creator promise fix

### DIFF
--- a/server/src/test-data/load.js
+++ b/server/src/test-data/load.js
@@ -141,13 +141,9 @@ const createEvent = (Creators, event, groups, users) => {
   const group = groups[event.group];
   const { name, details, sourceIdentifier, permalink, priority, responses, eventLocations } = event;
   return Creators.event({ name, details, sourceIdentifier, permalink, priority, group })
-    .then((e) => {
-      createEventLocations(Creators, e, eventLocations).then((em) => {
-        Promise.all(
-          responses.map(r => createEventResponse(Creators, e, r, em, users)),
-        );
-      });
-    });
+    .then(e => createEventLocations(Creators, e, eventLocations).then(em => Promise.all(
+      responses.map(r => createEventResponse(Creators, e, r, em, users)),
+    )));
 };
 
 const createEvents = (Creators, groups, users) =>


### PR DESCRIPTION
We were not returning the promise on event data creation, meaning the server thought it had finished creating test data when it really hadnt.

Before:
```
Executing (default): INSERT INTO `eventlocations` (`id`,`name`,`detail`,`icon`,`locationLatitude`,`locationLongitude`,`createdAt`,`updatedAt`,`eventId`) VALUES (NULL,'scene','12 WEBB STREET, NORTH PARRAMATTA NSW 2151','mci-target',-33.8031162,151.0169367,'2018-06-06 12:35:18.011 +00:00','2018-06-06 12:35:18.011 +00:00',3);
Finished creating test data
Executing (default): UPDATE `events` SET `primaryLocationId`=1,`updatedAt`='2018-06-06 12:35:18.046 +00:00' WHERE `id` = 1
Executing (default): INSERT INTO `eventresponses` (`id`,`status`,`detail`,`eta`,`locationLatitude`,`locationLongitude`,`locationTime`,`createdAt`,`updatedAt`,`eventId`,`userId`,`eventlocationId`) VALUES 
....etc...etc
```

After:
```
Executing (default): INSERT INTO `eventlocations` (`id`,`name`,`detail`,`icon`,`locationLatitude`,`locationLongitude`,`createdAt`,`updatedAt`,`eventId`) VALUES (NULL,'scene','12 WEBB STREET, NORTH PARRAMATTA NSW 2151','mci-target',-33.8031162,151.0169367,'2018-06-06 12:35:18.011 +00:00','2018-06-06 12:35:18.011 +00:00',3);
Executing (default): UPDATE `events` SET `primaryLocationId`=1,`updatedAt`='2018-06-06 12:35:18.046 +00:00' WHERE `id` = 1
Executing (default): INSERT INTO `eventresponses` (`id`,`status`,`detail`,`eta`,`locationLatitude`,`locationLongitude`,`locationTime`,`createdAt`,`updatedAt`,`eventId`,`userId`,`eventlocationId`) VALUES 
Finished creating test data
```

Closes #491