### PR TITLE
Server - Added field type to schedules

### DIFF
--- a/server/src/creators.js
+++ b/server/src/creators.js
@@ -13,7 +13,7 @@ export const getCreators = (models) => {
     organisation: ({ name }) =>
       Organisation.create({ name }),
 
-    schedule: ({ name, details, priority, startTime, endTime, group }) => {
+    schedule: ({ name, details, type, priority, startTime, endTime, group }) => {
       if (!group || !group.id) {
         return Promise.reject(Error('Must pass group'));
       }
@@ -26,6 +26,7 @@ export const getCreators = (models) => {
       return Schedule.create({
         name,
         details,
+        type: type || 'local',
         priority,
         startTime,
         endTime,

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -233,7 +233,7 @@ export const getHandlers = ({ models, creators: Creators, push }) => {
         return schedule.getGroup();
       },
       createSchedule(_, args) {
-        const { name, details, priority, startTime, endTime, groupId } = args.schedule;
+        const { name, details, type, priority, startTime, endTime, groupId } = args.schedule;
 
         return Group.findById(groupId)
           .then((group) => {
@@ -244,6 +244,7 @@ export const getHandlers = ({ models, creators: Creators, push }) => {
             return Creators.schedule({
               name,
               details,
+              type,
               priority,
               startTime,
               endTime,

--- a/server/src/models-mock.js
+++ b/server/src/models-mock.js
@@ -52,6 +52,7 @@ export const defineModels = () => {
   const ScheduleModel = db.define('schedule', {
     name: 'Test schedule',
     details: 'Details of test schedule',
+    type: 'local',
     priority: 1,
     startTime: 1514860289,
     endTime: 1514860289 + (60 * 60),

--- a/server/src/models.js
+++ b/server/src/models.js
@@ -48,6 +48,7 @@ export const defineModels = (db) => {
   const ScheduleModel = db.define('schedule', {
     name: { type: Sequelize.STRING },
     details: { type: Sequelize.STRING },
+    type: { type: Sequelize.STRING },
     priority: { type: Sequelize.INTEGER },
     startTime: { type: Sequelize.INTEGER },
     endTime: { type: Sequelize.INTEGER },

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -23,7 +23,7 @@ export const Schema = [
     name: String,
     type: String,
   }
-  
+
   input UserInput {
     id: Int!
     displayName: String,
@@ -52,6 +52,7 @@ export const Schema = [
   input CreateScheduleInput {
     name: String!
     details: String!
+    type: String
     startTime: Int!
     endTime: Int!
     groupId: Int!
@@ -147,7 +148,7 @@ export const Schema = [
     eventLocations: [LocationInput]
     groupId: Int!
   }
-  
+
   input UpdateGroupInput {
     id: Int!
     name: String!
@@ -268,6 +269,7 @@ export const Schema = [
     id: Int!
     name: String!
     details: String!
+    type: String!,
     priority: Int
     startTime: Int!
     endTime: Int!

--- a/server/src/test-data/fixtures.js
+++ b/server/src/test-data/fixtures.js
@@ -276,6 +276,7 @@ export const SCHEDULES = [
   {
     name: 'Wagga Wagga OOA availability',
     details: 'Flood Rescue operators required for Wednesday deployment to Wagga Wagga. Leave Monday return Thursday',
+    type: 'ooa',
     priority: 4,
     startTime: MONDAY,
     endTime: MONDAY + (60 * 60 * 24 * 3),
@@ -290,6 +291,7 @@ export const SCHEDULES = [
   {
     name: 'Kiama rescue availability',
     details: 'Ongoing availability for RCR, VR, GLR',
+    type: 'local',
     priority: 3,
     startTime: DISTANT_PAST,
     endTime: DISTANT_FUTURE,
@@ -303,6 +305,7 @@ export const SCHEDULES = [
   {
     name: 'Kiama storm availability',
     details: 'Non-urgent availability for storm jobs during this week',
+    type: 'local',
     priority: 5,
     startTime: MONDAY,
     endTime: MONDAY + (60 * 60 * 24 * 6),
@@ -317,6 +320,7 @@ export const SCHEDULES = [
   {
     name: 'Parramatta storm availability',
     details: 'Non-urgent availability for storm jobs',
+    type: 'local',
     priority: 5,
     startTime: DISTANT_PAST,
     endTime: DISTANT_FUTURE,
@@ -332,6 +336,7 @@ export const SCHEDULES = [
   {
     name: 'Metro L3',
     details: 'Metro - Flood Rescue operator availability',
+    type: 'local',
     priority: 2,
     startTime: MONDAY + (60 * 60 * 24 * 3),
     endTime: MONDAY + (60 * 60 * 24 * 6),
@@ -340,6 +345,7 @@ export const SCHEDULES = [
   {
     name: 'Metro IMT',
     details: 'Mtro - IMT operator availability',
+    type: 'local',
     priority: 3,
     startTime: MONDAY + (60 * 60 * 24 * 3),
     endTime: MONDAY + (60 * 60 * 24 * 6),
@@ -348,6 +354,7 @@ export const SCHEDULES = [
   {
     name: 'OCES - Weekly Meeting',
     details: 'Weekly Monday meeting',
+    type: 'local',
     priority: 9,
     startTime: MONDAY,
     endTime: MONDAY + (60 * 60 * 24 * 1),

--- a/server/src/test-data/load.js
+++ b/server/src/test-data/load.js
@@ -66,8 +66,8 @@ const createTags = (Creators, organisation) => {
 
 const createSchedule = (Creators, schedule, groups) => {
   const group = groups[schedule.group];
-  const { name, details, priority, startTime, endTime } = schedule;
-  return Creators.schedule({ name, details, priority, startTime, endTime, group });
+  const { name, details, type, priority, startTime, endTime } = schedule;
+  return Creators.schedule({ name, details, type, priority, startTime, endTime, group });
 };
 
 const createSchedules = (Creators, groups) => {


### PR DESCRIPTION
defaults to 'local' in the creator if not sent.

```
{
  "data": {
    "user": {
      "schedules": [
        {
          "name": "Wagga Wagga OOA availability",
          "details": "Flood Rescue operators required for Wednesday deployment to Wagga Wagga. Leave Monday return Thursday",
          "type": "ooa"
        },
        {
          "name": "Kiama rescue availability",
          "details": "Ongoing availability for RCR, VR, GLR",
          "type": "local"
        },
        {
          "name": "Kiama storm availability",
          "details": "Non-urgent availability for storm jobs during this week",
          "type": "local"
        },
        {
          "name": "Parramatta storm availability",
          "details": "Non-urgent availability for storm jobs",
          "type": "local"
        },
        {
          "name": "OCES - Weekly Meeting",
          "details": "Weekly Monday meeting",
          "type": "local"
        }
      ]
    }
  }
}
```