### PR TITLE
Client - Event response map GPS timeout fix

### DIFF
--- a/client/src/components/Events/SetResponse.js
+++ b/client/src/components/Events/SetResponse.js
@@ -65,7 +65,7 @@ class SetResponse extends Component {
             timeToScene: 'unknown',
           });
         },
-        { enableHighAccuracy: true, maximumAge: 60, distanceFilter: 0, timeout: 3000 },
+        { enableHighAccuracy: true, maximumAge: 60000, timeout: 15000 },
       );
     }
   }


### PR DESCRIPTION
Turns out my emulator gets a GPS fix stupidly fast and in real life the timeout needs to be a bit longer.

Also updated cache time and remove a superfluous distanceFilter variable. 