### PR TITLE
Client - remove progress spinner from event details

### DIFF
--- a/client/src/screens/events/Detail.js
+++ b/client/src/screens/events/Detail.js
@@ -302,7 +302,6 @@ class Detail extends Component {
     if (!event && !loading) {
       return (
         <Center>
-          <Progress />
           <Text>Unable to load event, or event no longer exists</Text>
         </Center>
       );


### PR DESCRIPTION
This was not meant to be in the previous PR.