### PR TITLE
Client - Fix bad array merge of group join

### DIFF
--- a/client/src/screens/groups/GroupDetails.js
+++ b/client/src/screens/groups/GroupDetails.js
@@ -198,8 +198,9 @@ const joinGroupMutation = graphql(JOIN_GROUP_MUTATION, {
           });
           // add new data to the cache
           data.user.groups.push(addUserToGroup);
-          data.user.schedules = _.merge(data.user.schedules, addUserToGroup.schedules);
-          data.user.events = _.merge(data.user.events, addUserToGroup.events);
+          data.user.schedules = _.concat(data.user.schedules, addUserToGroup.schedules);
+          data.user.events = _.concat(data.user.events, addUserToGroup.events);
+
           // write out cache
           store.writeQuery({
             query: CURRENT_USER_QUERY,


### PR DESCRIPTION
Dunno if this ever worked.

We were blowing away the old data not merging it with the new. would show as only having events for the new group not adding them together.