### PR TITLE
Audit logging to DB

### DIFF
--- a/server/src/__tests__/logger.js
+++ b/server/src/__tests__/logger.js
@@ -1,0 +1,7 @@
+import { setupLogger } from '../logger';
+
+
+it('compiles', () => {
+  const result = setupLogger();
+  expect(result).toBeDefined();
+});

--- a/server/src/logger.js
+++ b/server/src/logger.js
@@ -1,0 +1,46 @@
+import Sequelize from 'sequelize';
+
+const init = async ({ logDb, logModel }) => {
+  await logDb.sync({ force: true });
+
+  try {
+    await logModel.create({ source: 'core', action: 'Startup' });
+    console.log('Finished creating log database'); // eslint-disable-line no-console
+  } catch (e) {
+    console.log('Epic fail creating log database'); // eslint-disable-line no-console
+    console.log(e); // eslint-disable-line no-console
+  }
+};
+
+export const setupLogger = () => {
+  // initialize our database
+  const logDb = new Sequelize('avail-logger', null, null, {
+    dialect: 'sqlite',
+    storage: './avail.log.sqlite',
+    logging: console.log, // eslint-disable-line no-console
+  });
+
+  const logModel = logDb.define('log', {
+    source: { type: Sequelize.STRING },
+    action: { type: Sequelize.STRING },
+    payload: { type: Sequelize.STRING },
+  });
+
+  init({ logDb, logModel });
+
+  const logWriter = ({
+    source,
+    action,
+    payload,
+  }) => logModel.create({
+    source,
+    action,
+    payload: JSON.stringify(payload),
+  });
+
+  return {
+    logWriter,
+  };
+};
+
+export default setupLogger;

--- a/server/src/logic.js
+++ b/server/src/logic.js
@@ -87,18 +87,16 @@ export const getHandlers = ({ logWriter, models, creators: Creators, push, pubsu
       updateUserProfile(_, args, ctx) {
         // TODO support more basic fields
         const { displayName } = args.user;
-        return getAuthenticatedUser(ctx).then((user) => {
-          user.update({
-            displayName,
-          }).then((res) => {
-            logWriter({
-              source: user.username,
-              action: 'updateUserProfile',
-              payload: args.user,
-            });
-            return res;
+        return getAuthenticatedUser(ctx).then(user => user.update({
+          displayName,
+        }).then((res) => {
+          logWriter({
+            source: user.username,
+            action: 'updateUserProfile',
+            payload: args.user,
           });
-        });
+          return res;
+        }));
       },
       groups(user, args) {
         if (args.id) {

--- a/server/src/main.js
+++ b/server/src/main.js
@@ -9,6 +9,7 @@ import jwt from 'express-jwt';
 import jsonwebtoken from 'jsonwebtoken';
 import url from 'url';
 import { JWT_SECRET, DEFAULT_USER_ID, DEFAULT_DEVICE_UUID } from './config';
+import { setupLogger } from './logger';
 import { getSchema } from './schema';
 import { setupDb } from './db';
 import { getHandlers } from './logic';
@@ -26,13 +27,15 @@ const SUBSCRIPTIONS_PATH = '/subscriptions';
 
 const port = process.env.PORT ? process.env.PORT : GRAPHQL_PORT;
 
+const { logWriter } = setupLogger();
+
 const { models, db } = setupDb();
 const creators = getCreators(models);
 const { User, Device } = models;
 
 const push = getPushEmitters({ models });
 
-const handlers = getHandlers({ models, creators, push, pubsub });
+const handlers = getHandlers({ logWriter, models, creators, push, pubsub });
 const resolvers = getResolvers(handlers);
 const schema = getSchema(resolvers);
 


### PR DESCRIPTION
Module to allow audit logging of "things" to seperate database.

Using a seperate database for flexibility to allow log data to be seperate to the primary data store (cause if that gets fucked over it might be handy to have the audit log survive?)

Anything that was a "Create" I log the returned item
Anything that was an 'Update' I log the requested change

Objects into JSON so that are somewhat standard.

No data relationships to prevent any cascade deleting of data.

Never done this before, I welcome critical comments.