### PR TITLE
Restart immediately after applying codepush update

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -10,7 +10,7 @@ const codePushOptions = {
     (!__DEV__) ? codePush.CheckFrequency.ON_APP_RESUME
       : codePush.CheckFrequency.MANUAL),
   updateDialog: true,
-  installMode: codePush.InstallMode.ON_NEXT_RESUME,
+  installMode: codePush.InstallMode.IMMEDIATE,
 };
 
 // suppress false-positive isMounted() deprecation warning


### PR DESCRIPTION
* We need to revert this before we submit to the app store
* This should make it easier for people to update because we don't need to
  remind them to restart the app after applying an update.